### PR TITLE
PPT-501: converted plastic packaging impl

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/ConvertedPackagingCredit.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/ConvertedPackagingCredit.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.plasticpackagingtaxreturns.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class HumanMedicinesPlasticWeight(totalKg: Long)
+case class ConvertedPackagingCredit(totalInPence: Long)
 
-object HumanMedicinesPlasticWeight {
-  implicit val format: OFormat[HumanMedicinesPlasticWeight] = Json.format[HumanMedicinesPlasticWeight]
+object ConvertedPackagingCredit {
+  implicit val format: OFormat[ConvertedPackagingCredit] = Json.format[ConvertedPackagingCredit]
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/ImportedPlasticWeight.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/ImportedPlasticWeight.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtaxreturns.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class ImportedPlasticWeight(totalKg: Option[Long] = None, totalKgBelowThreshold: Option[Long] = None)
+case class ImportedPlasticWeight(totalKg: Long, totalKgBelowThreshold: Long)
 
 object ImportedPlasticWeight {
   implicit val format: OFormat[ImportedPlasticWeight] = Json.format[ImportedPlasticWeight]

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/ManufacturedPlasticWeight.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/ManufacturedPlasticWeight.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtaxreturns.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class ManufacturedPlasticWeight(totalKg: Option[Long] = None, totalKgBelowThreshold: Option[Long] = None)
+case class ManufacturedPlasticWeight(totalKg: Long, totalKgBelowThreshold: Long)
 
 object ManufacturedPlasticWeight {
   implicit val format: OFormat[ManufacturedPlasticWeight] = Json.format[ManufacturedPlasticWeight]

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturn.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturn.scala
@@ -20,10 +20,11 @@ import play.api.libs.json.{Json, OFormat}
 
 case class TaxReturn(
   id: String,
-  manufacturedPlasticWeight: ManufacturedPlasticWeight = ManufacturedPlasticWeight(),
-  importedPlasticWeight: ImportedPlasticWeight = ImportedPlasticWeight(),
-  humanMedicinesPlasticWeight: HumanMedicinesPlasticWeight = HumanMedicinesPlasticWeight(),
-  exportedPlasticWeight: Option[ExportedPlasticWeight] = None
+  manufacturedPlasticWeight: Option[ManufacturedPlasticWeight] = None,
+  importedPlasticWeight: Option[ImportedPlasticWeight] = None,
+  humanMedicinesPlasticWeight: Option[HumanMedicinesPlasticWeight] = None,
+  exportedPlasticWeight: Option[ExportedPlasticWeight] = None,
+  convertedPackagingCredit: Option[ConvertedPackagingCredit] = None
 )
 
 object TaxReturn {

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturnRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturnRequest.scala
@@ -17,10 +17,11 @@
 package uk.gov.hmrc.plasticpackagingtaxreturns.models
 
 case class TaxReturnRequest(
-  manufacturedPlasticWeight: ManufacturedPlasticWeight,
-  importedPlasticWeight: ImportedPlasticWeight,
-  humanMedicinesPlasticWeight: HumanMedicinesPlasticWeight,
-  exportedPlasticWeight: Option[ExportedPlasticWeight] = None
+  manufacturedPlasticWeight: Option[ManufacturedPlasticWeight],
+  importedPlasticWeight: Option[ImportedPlasticWeight],
+  humanMedicinesPlasticWeight: Option[HumanMedicinesPlasticWeight],
+  exportedPlasticWeight: Option[ExportedPlasticWeight],
+  convertedPackagingCredit: Option[ConvertedPackagingCredit]
 ) {
 
   def toTaxReturn(providerId: String): TaxReturn =
@@ -28,7 +29,8 @@ case class TaxReturnRequest(
               manufacturedPlasticWeight = this.manufacturedPlasticWeight,
               importedPlasticWeight = this.importedPlasticWeight,
               humanMedicinesPlasticWeight = this.humanMedicinesPlasticWeight,
-              exportedPlasticWeight = this.exportedPlasticWeight
+              exportedPlasticWeight = this.exportedPlasticWeight,
+              convertedPackagingCredit = this.convertedPackagingCredit
     )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/AuthTestSupport.scala
@@ -36,7 +36,7 @@ trait AuthTestSupport extends MockitoSugar {
   lazy val mockLogger: Logger               = mock[Logger]
 
   val enrolment: Predicate = Enrolment(pptEnrolment)
-  val utr                  = "222222222"
+  val utr                  = "7777777"
 
   def withAuthorizedUser(user: SignedInUser = newUser(utr, "external1")): Unit =
     when(

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnBuilder.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnBuilder.scala
@@ -23,6 +23,12 @@ import uk.gov.hmrc.plasticpackagingtaxreturns.models.{
   ManufacturedPlasticWeight,
   TaxReturn
 }
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.{
+  ConvertedPackagingCredit,
+  ImportedPlasticWeight,
+  ManufacturedPlasticWeight,
+  TaxReturn
+}
 
 //noinspection ScalaStyle
 trait TaxReturnBuilder {
@@ -37,24 +43,29 @@ trait TaxReturnBuilder {
 
   def withId(id: String): TaxReturnModifier = _.copy(id = id)
 
-  def withManufacturedPlasticWeight(totalKg: Option[Long], totalKgBelowThreshold: Option[Long]): TaxReturnModifier =
+  def withManufacturedPlasticWeight(totalKg: Long, totalKgBelowThreshold: Long): TaxReturnModifier =
     _.copy(manufacturedPlasticWeight =
-      ManufacturedPlasticWeight(totalKg = totalKg, totalKgBelowThreshold = totalKgBelowThreshold)
+      Some(ManufacturedPlasticWeight(totalKg = totalKg, totalKgBelowThreshold = totalKgBelowThreshold))
     )
 
-  def withImportedPlasticWeight(totalKg: Option[Long], totalKgBelowThreshold: Option[Long]): TaxReturnModifier =
+  def withImportedPlasticWeight(totalKg: Long, totalKgBelowThreshold: Long): TaxReturnModifier =
     _.copy(importedPlasticWeight =
-      ImportedPlasticWeight(totalKg = totalKg, totalKgBelowThreshold = totalKgBelowThreshold)
+      Some(ImportedPlasticWeight(totalKg = totalKg, totalKgBelowThreshold = totalKgBelowThreshold))
     )
 
-  def withHumanMedicinesPlasticWeight(totalKg: Option[Long]): TaxReturnModifier =
+  def withHumanMedicinesPlasticWeight(totalKg: Long): TaxReturnModifier =
     _.copy(humanMedicinesPlasticWeight =
-      HumanMedicinesPlasticWeight(totalKg = totalKg)
+      Some(HumanMedicinesPlasticWeight(totalKg = totalKg))
     )
 
   def withDirectExportDetails(totalKg: Long, totalValueForCreditInPence: Long): TaxReturnModifier =
     _.copy(exportedPlasticWeight =
       Some(ExportedPlasticWeight(totalKg = totalKg, totalValueForCreditInPence = totalValueForCreditInPence))
+    )
+
+  def withConvertedPlasticPackagingCredit(totalPence: Long): TaxReturnModifier =
+    _.copy(convertedPackagingCredit =
+      Some(ConvertedPackagingCredit(totalPence))
     )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnRequestBuilder.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnRequestBuilder.scala
@@ -16,6 +16,12 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.builders
 
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.{
+  ConvertedPackagingCredit,
+  ImportedPlasticWeight,
+  ManufacturedPlasticWeight,
+  TaxReturnRequest
+}
 import uk.gov.hmrc.plasticpackagingtaxreturns.models._
 
 //noinspection ScalaStyle
@@ -27,22 +33,28 @@ trait TaxReturnRequestBuilder {
     modifiers.foldLeft(modelWithDefaults)((current, modifier) => modifier(current))
 
   private def modelWithDefaults: TaxReturnRequest =
-    TaxReturnRequest(manufacturedPlasticWeight = ManufacturedPlasticWeight(Some(5), Some(5)),
-                     importedPlasticWeight = ImportedPlasticWeight(Some(6), Some(6)),
-                     humanMedicinesPlasticWeight = HumanMedicinesPlasticWeight(Some(1)),
-                     exportedPlasticWeight = Some(ExportedPlasticWeight(2000, 460089))
+    TaxReturnRequest(manufacturedPlasticWeight = Some(ManufacturedPlasticWeight(5, 5)),
+                     importedPlasticWeight = Some(ImportedPlasticWeight(6, 6)),
+                     humanMedicinesPlasticWeight = Some(HumanMedicinesPlasticWeight(1)),
+                     exportedPlasticWeight = Some(ExportedPlasticWeight(2000, 460089)),
+                     convertedPackagingCredit = Some(ConvertedPackagingCredit(1010))
     )
 
   def withManufacturedPlasticWeight(manufacturedPlasticWeight: ManufacturedPlasticWeight): TaxReturnRequestModifier =
-    _.copy(manufacturedPlasticWeight = manufacturedPlasticWeight)
+    _.copy(manufacturedPlasticWeight = Some(manufacturedPlasticWeight))
 
   def withImportedPlasticWeight(importedPlasticWeight: ImportedPlasticWeight): TaxReturnRequestModifier =
-    _.copy(importedPlasticWeight = importedPlasticWeight)
+    _.copy(importedPlasticWeight = Some(importedPlasticWeight))
+
+  def withConvertedPlasticPackagingCredit(
+    convertedPlasticPackagingCredit: ConvertedPackagingCredit
+  ): TaxReturnRequestModifier =
+    _.copy(convertedPackagingCredit = Some(convertedPlasticPackagingCredit))
 
   def withHumanMedicinesPlasticWeight(
     humanMedicinesPlasticWeight: HumanMedicinesPlasticWeight
   ): TaxReturnRequestModifier =
-    _.copy(humanMedicinesPlasticWeight = humanMedicinesPlasticWeight)
+    _.copy(humanMedicinesPlasticWeight = Some(humanMedicinesPlasticWeight))
 
   def withDirectExportDetails(directExportDetails: ExportedPlasticWeight): TaxReturnRequestModifier =
     _.copy(exportedPlasticWeight = Some(directExportDetails))

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/repositories/TaxReturnRepositoryItSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/repositories/TaxReturnRepositoryItSpec.scala
@@ -52,7 +52,7 @@ class TaxReturnRepositoryItSpec
       .futureValue
       .toInt
 
-  private def gienTaxReturnExists(taxReturns: TaxReturn*): Unit =
+  private def givenTaxReturnExists(taxReturns: TaxReturn*): Unit =
     repository.collection.insert(ordered = true).many(taxReturns).futureValue
 
   "Create" should {
@@ -66,10 +66,11 @@ class TaxReturnRepositoryItSpec
 
   "Update" should {
     "update the tax return" in {
-      gienTaxReturnExists(aTaxReturn())
-      val taxReturn = aTaxReturn(withManufacturedPlasticWeight(totalKg = Some(5), totalKgBelowThreshold = Some(4)),
-                                 withImportedPlasticWeight(totalKg = Some(3), totalKgBelowThreshold = Some(2)),
-                                 withHumanMedicinesPlasticWeight(totalKg = Some(1))
+      givenTaxReturnExists(aTaxReturn())
+      val taxReturn = aTaxReturn(withManufacturedPlasticWeight(totalKg = 5, totalKgBelowThreshold = 4),
+                                 withImportedPlasticWeight(totalKg = 3, totalKgBelowThreshold = 2),
+                                 withHumanMedicinesPlasticWeight(totalKg = 1),
+                                 withConvertedPlasticPackagingCredit(totalPence = 1010)
       )
 
       repository.update(taxReturn).futureValue mustBe Some(taxReturn)
@@ -94,11 +95,13 @@ class TaxReturnRepositoryItSpec
   "Find by ID" should {
     "return the persisted tax return" when {
       "one exists with ID" in {
-        val taxReturn = aTaxReturn(withManufacturedPlasticWeight(totalKg = Some(5), totalKgBelowThreshold = Some(4)),
-                                   withImportedPlasticWeight(totalKg = Some(3), totalKgBelowThreshold = Some(2)),
-                                   withHumanMedicinesPlasticWeight(totalKg = Some(1))
+        val taxReturn = aTaxReturn(withManufacturedPlasticWeight(totalKg = 5, totalKgBelowThreshold = 4),
+                                   withImportedPlasticWeight(totalKg = 3, totalKgBelowThreshold = 2),
+                                   withHumanMedicinesPlasticWeight(totalKg = 1),
+                                   withConvertedPlasticPackagingCredit(totalPence = 1010)
         )
-        gienTaxReturnExists(taxReturn)
+
+        givenTaxReturnExists(taxReturn)
 
         repository.findById(taxReturn.id).futureValue mustBe Some(taxReturn)
 
@@ -111,7 +114,7 @@ class TaxReturnRepositoryItSpec
       "none exist with id" in {
         val taxReturn1 = aTaxReturn(withId("some-other-id"))
         val taxReturn2 = aTaxReturn()
-        gienTaxReturnExists(taxReturn1, taxReturn2)
+        givenTaxReturnExists(taxReturn1, taxReturn2)
 
         repository.findById("non-existing-id").futureValue mustBe None
 
@@ -123,7 +126,7 @@ class TaxReturnRepositoryItSpec
   "Delete" should {
     "remove the tax return" in {
       val taxReturn = aTaxReturn()
-      gienTaxReturnExists(taxReturn)
+      givenTaxReturnExists(taxReturn)
 
       repository.delete(taxReturn).futureValue
 
@@ -135,7 +138,7 @@ class TaxReturnRepositoryItSpec
         val taxReturn1 = aTaxReturn()
         val taxReturn2 = aTaxReturn(withId("id1"))
         val taxReturn3 = aTaxReturn(withId("id2"))
-        gienTaxReturnExists(taxReturn2, taxReturn3)
+        givenTaxReturnExists(taxReturn2, taxReturn3)
 
         repository.delete(taxReturn1).futureValue
 


### PR DESCRIPTION
- Changed TaxReturn model to contain optional objects rather than values within those objects. It makes more logical sense as values inside members of TaxReturn are all mandatory.