### PR TITLE
PPTP-426: implementation for display registration details

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/config/AppConfig.scala
@@ -23,10 +23,17 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig) {
+  lazy val eisHost: String = servicesConfig.baseUrl("eis")
+
+  def subscriptionDisplayUrl(pptReference: String): String =
+    s"$eisHost/plastic-packaging-tax/subscriptions/PPT/$pptReference/display"
 
   val authBaseUrl: String = servicesConfig.baseUrl("auth")
 
   val auditingEnabled: Boolean   = config.get[Boolean]("auditing.enabled")
   val graphiteHost: String       = config.get[String]("microservice.metrics.graphite.host")
   val dbTimeToLiveInSeconds: Int = config.get[Int]("mongodb.timeToLiveInSeconds")
+
+  val eisEnvironment: String = config.get[String]("eis.environment")
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/EISConnector.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors
+
+import play.api.http.{HeaderNames, MimeTypes}
+import uk.gov.hmrc.plasticpackagingtaxreturns.config.AppConfig
+
+trait EISConnector {
+  val appConfig: AppConfig
+
+  val headers: Seq[(String, String)] =
+    Seq("Environment" -> appConfig.eisEnvironment, HeaderNames.ACCEPT -> MimeTypes.JSON)
+
+  val correlationId = "CorrelationId"
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/SubscriptionsConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/SubscriptionsConnector.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors
+
+import com.kenshoo.play.metrics.Metrics
+import play.api.Logger
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, UpstreamErrorResponse}
+import uk.gov.hmrc.plasticpackagingtaxreturns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.SubscriptionDisplayResponse
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.registration.PptSubscription
+
+import java.util.UUID
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubscriptionsConnector @Inject() (httpClient: HttpClient, override val appConfig: AppConfig, metrics: Metrics)(
+  implicit ec: ExecutionContext
+) extends EISConnector {
+
+  private val logger = Logger(this.getClass)
+
+  def getSubscription(pptReference: String)(implicit hc: HeaderCarrier): Future[Either[Int, PptSubscription]] = {
+    val timer               = metrics.defaultRegistry.timer("ppt.subscription.display.timer").time()
+    val correlationIdHeader = correlationId -> UUID.randomUUID().toString
+    httpClient.GET[SubscriptionDisplayResponse](appConfig.subscriptionDisplayUrl(pptReference),
+                                                headers = headers :+ correlationIdHeader
+    )
+      .andThen { case _ => timer.stop() }
+      .map(response => Right(response.toPptSubscription(pptReference = pptReference)))
+      .recover {
+        case httpEx: UpstreamErrorResponse =>
+          logger.error(s"Upstream error returned, status: ${httpEx.statusCode}, body: ${httpEx.getMessage()}")
+          Left(httpEx.statusCode)
+        case ex: Exception =>
+          logger.error(s"Subscription display with Correlation ID [${correlationIdHeader._2}] and " +
+                         s"PptReference [$pptReference] is currently unavailable due to [${ex.getMessage}]",
+                       ex
+          )
+          Left(INTERNAL_SERVER_ERROR)
+      }
+  }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/AddressDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/AddressDetails.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class AddressDetails(
+  addressLine1: String,
+  addressLine2: String,
+  addressLine3: Option[String] = None,
+  addressLine4: Option[String] = None,
+  postalCode: Option[String] = None,
+  countryCode: String
+)
+
+object AddressDetails {
+  implicit val format: OFormat[AddressDetails] = Json.format[AddressDetails]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/BusinessCorrespondenceDetails.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class BusinessCorrespondenceDetails(
+  addressLine1: String,
+  addressLine2: String,
+  addressLine3: Option[String] = None,
+  addressLine4: Option[String] = None,
+  postalCode: Option[String] = None,
+  countryCode: String
+)
+
+object BusinessCorrespondenceDetails {
+
+  implicit val format: OFormat[BusinessCorrespondenceDetails] =
+    Json.format[BusinessCorrespondenceDetails]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/ContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/ContactDetails.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ContactDetails(email: String, telephone: String, mobileNumber: Option[String] = None)
+
+object ContactDetails {
+  implicit val format: OFormat[ContactDetails] = Json.format[ContactDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/CustomerDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/CustomerDetails.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.CustomerType.CustomerType
+
+case class CustomerDetails(
+  customerType: CustomerType,
+  individualDetails: Option[IndividualDetails] = None,
+  organisationDetails: Option[OrganisationDetails] = None
+)
+
+object CustomerDetails {
+  implicit val format: OFormat[CustomerDetails] = Json.format[CustomerDetails]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/CustomerType.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/CustomerType.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Format, Reads, Writes}
+
+object CustomerType extends Enumeration {
+  type CustomerType = Value
+  val Individual: Value   = Value
+  val Organisation: Value = Value
+
+  implicit val format: Format[CustomerType] =
+    Format(Reads.enumNameReads(CustomerType), Writes.enumNameWrites)
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/Declaration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/Declaration.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Declaration(declarationBox1: Boolean)
+
+object Declaration {
+  implicit val format: OFormat[Declaration] = Json.format[Declaration]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/IndividualDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/IndividualDetails.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class IndividualDetails(
+  title: Option[String] = None,
+  firstName: String,
+  middleName: Option[String] = None,
+  lastName: String
+)
+
+object IndividualDetails {
+  implicit val format: OFormat[IndividualDetails] = Json.format[IndividualDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/LegalEntityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/LegalEntityDetails.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+import scala.language.implicitConversions
+
+case class LegalEntityDetails(
+  dateOfApplication: String,
+  customerIdentification1: String,
+  customerIdentification2: Option[String] = None,
+  customerDetails: CustomerDetails,
+  groupSubscriptionFlag: Boolean = false
+)
+
+object LegalEntityDetails {
+
+  implicit val format: OFormat[LegalEntityDetails] = Json.format[LegalEntityDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/OrganisationDetails.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class OrganisationDetails(organisationType: Option[String] = None, organisationName: Option[String])
+
+object OrganisationDetails {
+  implicit val format: OFormat[OrganisationDetails] = Json.format[OrganisationDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/PrimaryContactDetails.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+
+case class PrimaryContactDetails(name: String, contactDetails: ContactDetails, positionInCompany: String)
+
+object PrimaryContactDetails {
+  implicit val format: OFormat[PrimaryContactDetails] = Json.format[PrimaryContactDetails]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/PrincipalPlaceOfBusinessDetails.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.Json
+
+case class PrincipalPlaceOfBusinessDetails(addressDetails: AddressDetails, contactDetails: ContactDetails)
+
+object PrincipalPlaceOfBusinessDetails {
+  implicit val format = Json.format[PrincipalPlaceOfBusinessDetails]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/Subscription.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/Subscription.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group.GroupSubscription
+
+import scala.language.implicitConversions
+
+case class Subscription(
+  legalEntityDetails: LegalEntityDetails,
+  principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
+  primaryContactDetails: PrimaryContactDetails,
+  businessCorrespondenceDetails: BusinessCorrespondenceDetails,
+  declaration: Declaration,
+  taxObligationStartDate: String,
+  last12MonthTotalTonnageAmt: Option[Long] = None,
+  groupSubscription: Option[GroupSubscription] = None
+)
+
+object Subscription {
+  implicit val format: OFormat[Subscription] = Json.format[Subscription]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/group/GroupDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/group/GroupDetails.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.{
+  AddressDetails,
+  ContactDetails,
+  IndividualDetails,
+  OrganisationDetails
+}
+
+case class GroupDetails(
+  relationship: String,
+  customerIdentification1: String,
+  customerIdentification2: Option[String],
+  organisationDetails: Option[OrganisationDetails],
+  individualDetails: Option[IndividualDetails],
+  addressDetails: AddressDetails,
+  contactDetails: ContactDetails
+)
+
+object GroupDetails {
+  implicit val format: OFormat[GroupDetails] = Json.format[GroupDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/group/GroupSubscription.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/group/GroupSubscription.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group
+
+import play.api.libs.json.{Json, OFormat}
+
+case class GroupSubscription(representativeControl: Boolean, groupDetails: GroupDetails, allMembersControl: Boolean)
+
+object GroupSubscription {
+  implicit val format: OFormat[GroupSubscription] = Json.format[GroupSubscription]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/ChangeOfCircumstanceDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/ChangeOfCircumstanceDetails.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ChangeOfCircumstanceDetails(
+  changeOfCircumstance: String,
+  deregistrationDetails: Option[DeregistrationDetails] = None
+)
+
+object ChangeOfCircumstanceDetails {
+
+  implicit val format: OFormat[ChangeOfCircumstanceDetails] =
+    Json.format[ChangeOfCircumstanceDetails]
+
+}
+
+case class DeregistrationDetails(deregistrationReason: String, deregistrationDate: String)
+
+object DeregistrationDetails {
+
+  implicit val format: OFormat[DeregistrationDetails] =
+    Json.format[DeregistrationDetails]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/SubscriptionDisplayResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/SubscriptionDisplayResponse.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription._
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group.GroupSubscription
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.registration.{
+  Address,
+  IncorporationDetails,
+  PptSubscription,
+  SoleTraderIncorporationDetails,
+  OrganisationDetails => PPTOrganisationDetails,
+  PrimaryContactDetails => PPTPrimaryContactDetails
+}
+
+case class SubscriptionDisplayResponse(
+  processingDate: String,
+  changeOfCircumstanceDetails: ChangeOfCircumstanceDetails,
+  legalEntityDetails: LegalEntityDetails,
+  principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
+  primaryContactDetails: PrimaryContactDetails,
+  businessCorrespondenceDetails: BusinessCorrespondenceDetails,
+  taxObligationStartDate: String,
+  last12MonthTotalTonnageAmt: Option[BigDecimal],
+  declaration: Declaration,
+  groupSubscription: Option[GroupSubscription]
+) {
+
+  def toPptSubscription(pptReference: String): PptSubscription =
+    PptSubscription(pptReference = pptReference,
+                    primaryContactDetails = toPptPrimaryContactDetails,
+                    organisationDetails = toPptOrganisationDetails
+    )
+
+  private def toPptOrganisationDetails = {
+    val pptOrgDetails = PPTOrganisationDetails(
+      organisationType =
+        this.legalEntityDetails.customerDetails.organisationDetails.flatMap(_.organisationType),
+      businessRegisteredAddress = Some(toPptAddress(this.principalPlaceOfBusinessDetails.addressDetails))
+    )
+    populateOrganisationTypeDetails(pptOrgDetails)
+  }
+
+  private def populateOrganisationTypeDetails(organisationDetails: PPTOrganisationDetails): PPTOrganisationDetails =
+    this.legalEntityDetails.customerDetails.customerType match {
+      case CustomerType.Individual   => organisationDetails.copy(soleTraderDetails = getSoleTraderDetails)
+      case CustomerType.Organisation => organisationDetails.copy(incorporationDetails = getUkCompanyDetails)
+    }
+
+  private def getUkCompanyDetails =
+    Some(
+      IncorporationDetails(
+        companyName =
+          this.legalEntityDetails.customerDetails.organisationDetails.flatMap(_.organisationName),
+        phoneNumber = Some(this.principalPlaceOfBusinessDetails.contactDetails.telephone),
+        email = Some(this.principalPlaceOfBusinessDetails.contactDetails.email)
+      )
+    )
+
+  private def getSoleTraderDetails =
+    Some(
+      SoleTraderIncorporationDetails(
+        firstName = this.legalEntityDetails.customerDetails.individualDetails.map(_.firstName),
+        lastName = this.legalEntityDetails.customerDetails.individualDetails.map(_.lastName)
+      )
+    )
+
+  private def toPptAddress(addressDetails: AddressDetails) =
+    Address(addressLine1 = addressDetails.addressLine1,
+            addressLine2 = addressDetails.addressLine2,
+            addressLine3 = addressDetails.addressLine3,
+            addressLine4 = addressDetails.addressLine4,
+            postCode = addressDetails.postalCode
+    )
+
+  private def toPptAddress(businessCorrespondenceDetails: BusinessCorrespondenceDetails) =
+    Address(addressLine1 = businessCorrespondenceDetails.addressLine1,
+            addressLine2 = businessCorrespondenceDetails.addressLine2,
+            addressLine3 = businessCorrespondenceDetails.addressLine3,
+            addressLine4 = businessCorrespondenceDetails.addressLine4,
+            postCode = businessCorrespondenceDetails.postalCode
+    )
+
+  private def toPptPrimaryContactDetails =
+    PPTPrimaryContactDetails(fullName = Some(this.primaryContactDetails.name),
+                             address = Some(toPptAddress(this.businessCorrespondenceDetails)),
+                             jobTitle = Some(this.primaryContactDetails.positionInCompany),
+                             email = Some(this.primaryContactDetails.contactDetails.email),
+                             phoneNumber = Some(this.primaryContactDetails.contactDetails.telephone)
+    )
+
+}
+
+object SubscriptionDisplayResponse {
+
+  implicit val format: OFormat[SubscriptionDisplayResponse] =
+    Json.format[SubscriptionDisplayResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/SubscriptionController.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers
+
+import play.api.mvc._
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.SubscriptionsConnector
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.Authenticator
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.response.JSONResponses
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class SubscriptionController @Inject() (
+  subscriptionsConnector: SubscriptionsConnector,
+  authenticator: Authenticator,
+  override val controllerComponents: ControllerComponents
+)(implicit executionContext: ExecutionContext)
+    extends BackendController(controllerComponents) with JSONResponses {
+
+  def get(pptReference: String): Action[AnyContent] =
+    authenticator.authorisedAction(parse.default) { implicit request =>
+      subscriptionsConnector.getSubscription(pptReference).map {
+        case Right(response)       => Ok(response)
+        case Left(errorStatusCode) => new Status(errorStatusCode)
+      }
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/Address.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/Address.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.registration
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Address(
+  addressLine1: String,
+  addressLine2: String,
+  addressLine3: Option[String] = None,
+  addressLine4: Option[String] = None,
+  postCode: Option[String] = None
+)
+
+object Address {
+  implicit val format: OFormat[Address] = Json.format[Address]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/IncorporationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/IncorporationDetails.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.registration
+
+import play.api.libs.json.{Format, Json}
+
+case class IncorporationDetails(companyName: Option[String], phoneNumber: Option[String], email: Option[String])
+
+object IncorporationDetails {
+
+  implicit val format: Format[IncorporationDetails] = Json.format[IncorporationDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/OrganisationDetails.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.registration
+
+import play.api.libs.json.{Json, OFormat}
+
+case class OrganisationDetails(
+  isBasedInUk: Option[Boolean] = None,
+  organisationType: Option[String] = None,
+  businessRegisteredAddress: Option[Address] = None,
+  safeNumber: Option[String] = None,
+  soleTraderDetails: Option[SoleTraderIncorporationDetails] = None,
+  incorporationDetails: Option[IncorporationDetails] = None
+)
+
+object OrganisationDetails {
+  implicit val format: OFormat[OrganisationDetails] = Json.format[OrganisationDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/PptSubscription.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/PptSubscription.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.registration
+
+import play.api.libs.json.{Json, OFormat}
+
+case class PptSubscription(
+  pptReference: String,
+  primaryContactDetails: PrimaryContactDetails = PrimaryContactDetails(),
+  organisationDetails: OrganisationDetails = OrganisationDetails()
+)
+
+object PptSubscription {
+  implicit val format: OFormat[PptSubscription] = Json.format[PptSubscription]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/PrimaryContactDetails.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.registration
+
+import play.api.libs.json.{Json, OFormat}
+
+case class PrimaryContactDetails(
+  fullName: Option[String] = None,
+  jobTitle: Option[String] = None,
+  email: Option[String] = None,
+  phoneNumber: Option[String] = None,
+  useRegisteredAddress: Option[Boolean] = None,
+  address: Option[Address] = None
+)
+
+object PrimaryContactDetails {
+  implicit val format: OFormat[PrimaryContactDetails] = Json.format[PrimaryContactDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/SoleTraderIncorporationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/registration/SoleTraderIncorporationDetails.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.registration
+
+import play.api.libs.json.{Format, Json}
+
+case class SoleTraderIncorporationDetails(firstName: Option[String], lastName: Option[String])
+
+object SoleTraderIncorporationDetails {
+
+  implicit val format: Format[SoleTraderIncorporationDetails] =
+    Json.format[SoleTraderIncorporationDetails]
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,3 +3,6 @@
 POST        /returns                 uk.gov.hmrc.plasticpackagingtaxreturns.controllers.ReturnsController.create()
 PUT         /returns/:id             uk.gov.hmrc.plasticpackagingtaxreturns.controllers.ReturnsController.update(id)
 GET         /returns/:id             uk.gov.hmrc.plasticpackagingtaxreturns.controllers.ReturnsController.get(id)
+
+# EIS subscription
+GET         /subscriptions/:pptReference   uk.gov.hmrc.plasticpackagingtaxreturns.controllers.SubscriptionController.get(pptReference: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -134,6 +134,12 @@ microservice {
       host = localhost
       port = 8500
     }
+    eis {
+      host = localhost
+      port = 8506
+      url = "http://localhost:8506"
+    }
   }
 }
 
+eis.environment = "ist0"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,7 +16,8 @@ object AppDependencies {
                  "org.mockito"             % "mockito-core"          % "3.9.0"    % Test,
                  "org.scalatestplus"      %% "scalatestplus-mockito" % "1.0.0-M2" % Test,
                  "com.vladsch.flexmark"    % "flexmark-all"          % "0.36.8"   % "test, it",
-                 "org.scalatestplus.play" %% "scalatestplus-play"    % "5.1.0"    % "test, it"
+                 "org.scalatestplus.play" %% "scalatestplus-play"    % "5.1.0"    % "test, it",
+                 "com.github.tomakehurst"  % "wiremock-jre8"         % "2.26.3"   % "test, it"
   )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/SubscriptionMapperValidator.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/SubscriptionMapperValidator.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.Subscription
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.registration.PptSubscription
+
+trait SubscriptionMapperValidator extends AnyWordSpec with Matchers {
+
+  def validatePptSubscriptionMapping(
+    pptReference: String,
+    pptSubscription: PptSubscription,
+    subscription: Subscription
+  ): Unit = {
+
+    pptSubscription.pptReference mustBe pptReference
+
+    pptSubscription.primaryContactDetails.fullName mustBe Some(subscription.primaryContactDetails.name)
+    pptSubscription.primaryContactDetails.jobTitle mustBe Some(subscription.primaryContactDetails.positionInCompany)
+    pptSubscription.primaryContactDetails.email mustBe Some(subscription.primaryContactDetails.contactDetails.email)
+    pptSubscription.primaryContactDetails.phoneNumber mustBe Some(
+      subscription.primaryContactDetails.contactDetails.telephone
+    )
+    pptSubscription.primaryContactDetails.address.get.addressLine1 mustBe
+      subscription.businessCorrespondenceDetails.addressLine1
+
+    pptSubscription.primaryContactDetails.address.get.addressLine2 mustBe
+      subscription.businessCorrespondenceDetails.addressLine2
+
+    pptSubscription.primaryContactDetails.address.get.addressLine3 mustBe
+      subscription.businessCorrespondenceDetails.addressLine3
+
+    pptSubscription.primaryContactDetails.address.get.addressLine4 mustBe
+      subscription.businessCorrespondenceDetails.addressLine4
+
+    pptSubscription.primaryContactDetails.address.get.postCode mustBe
+      subscription.businessCorrespondenceDetails.postalCode
+
+    pptSubscription.organisationDetails.organisationType mustBe Some(
+      subscription.legalEntityDetails.customerDetails.organisationDetails.get.organisationType.get
+    )
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine1 mustBe
+      subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine1
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine2 mustBe
+      subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine2
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine3 mustBe
+      subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine3
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine4 mustBe
+      subscription.principalPlaceOfBusinessDetails.addressDetails.addressLine4
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.postCode mustBe
+      subscription.principalPlaceOfBusinessDetails.addressDetails.postalCode
+  }
+
+  protected def validateSoleTaderPptSubscriptionMapping(
+    pptReference: String,
+    pptSubscription: PptSubscription,
+    soleTraderSubscription: Subscription
+  ): Unit = {
+    pptSubscription.pptReference mustBe pptReference
+
+    pptSubscription.primaryContactDetails.fullName mustBe Some(soleTraderSubscription.primaryContactDetails.name)
+    pptSubscription.primaryContactDetails.jobTitle mustBe Some(
+      soleTraderSubscription.primaryContactDetails.positionInCompany
+    )
+    pptSubscription.primaryContactDetails.email mustBe Some(
+      soleTraderSubscription.primaryContactDetails.contactDetails.email
+    )
+    pptSubscription.primaryContactDetails.phoneNumber mustBe Some(
+      soleTraderSubscription.primaryContactDetails.contactDetails.telephone
+    )
+    pptSubscription.primaryContactDetails.address.get.addressLine1 mustBe
+      soleTraderSubscription.businessCorrespondenceDetails.addressLine1
+
+    pptSubscription.primaryContactDetails.address.get.addressLine2 mustBe
+      soleTraderSubscription.businessCorrespondenceDetails.addressLine2
+
+    pptSubscription.primaryContactDetails.address.get.addressLine3 mustBe
+      soleTraderSubscription.businessCorrespondenceDetails.addressLine3
+
+    pptSubscription.primaryContactDetails.address.get.addressLine4 mustBe
+      soleTraderSubscription.businessCorrespondenceDetails.addressLine4
+
+    pptSubscription.primaryContactDetails.address.get.postCode mustBe
+      soleTraderSubscription.businessCorrespondenceDetails.postalCode
+
+    pptSubscription.organisationDetails.organisationType mustBe None
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine1 mustBe
+      soleTraderSubscription.principalPlaceOfBusinessDetails.addressDetails.addressLine1
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine2 mustBe
+      soleTraderSubscription.principalPlaceOfBusinessDetails.addressDetails.addressLine2
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine3 mustBe
+      soleTraderSubscription.principalPlaceOfBusinessDetails.addressDetails.addressLine3
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.addressLine4 mustBe
+      soleTraderSubscription.principalPlaceOfBusinessDetails.addressDetails.addressLine4
+
+    pptSubscription.organisationDetails.businessRegisteredAddress.get.postCode mustBe
+      soleTraderSubscription.principalPlaceOfBusinessDetails.addressDetails.postalCode
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/ConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/ConnectorISpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.it
+
+import com.codahale.metrics.{MetricFilter, SharedMetricRegistries, Timer}
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.kenshoo.play.metrics.Metrics
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.DefaultAwaitTimeout
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
+
+import scala.concurrent.ExecutionContext
+
+class ConnectorISpec extends WiremockTestServer with GuiceOneAppPerSuite with DefaultAwaitTimeout {
+
+  protected val httpClient: DefaultHttpClient = app.injector.instanceOf[DefaultHttpClient]
+  protected val metrics: Metrics              = app.injector.instanceOf[Metrics]
+
+  protected implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+  protected implicit val hc: HeaderCarrier    = HeaderCarrier()
+
+  override def fakeApplication(): Application = {
+    SharedMetricRegistries.clear()
+    new GuiceApplicationBuilder().configure(overrideConfig).build()
+  }
+
+  def overrideConfig: Map[String, Any] =
+    Map("microservice.services.eis.host" -> wireHost, "microservice.services.eis.port" -> wirePort)
+
+  def getTimer(name: String): Timer =
+    SharedMetricRegistries
+      .getOrCreate("plastic-packaging-tax-returns")
+      .getTimers(MetricFilter.startsWith(name))
+      .get(name)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    WireMock.configureFor(wireHost, wirePort)
+    wireMockServer.start()
+  }
+
+  override protected def beforeEach(): Unit =
+    SharedMetricRegistries.clear()
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    wireMockServer.stop()
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/Injector.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/Injector.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.it
+
+import com.codahale.metrics.SharedMetricRegistries
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.reflect.ClassTag
+
+trait Injector {
+
+  /**
+    * Clearing shared metrics registries to avoid `A metric named jvm.attribute.vendor already exists` error.
+    *
+    * It appears very often with places with injector. This is enough solution for this problem.
+    *
+    * Reference and other solutions: https://github.com/kenshoo/metrics-play/issues/74
+    */
+  SharedMetricRegistries.clear()
+
+  private val injector = GuiceApplicationBuilder().injector()
+
+  def instanceOf[T <: AnyRef](implicit classTag: ClassTag[T]): T = injector.instanceOf[T]
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/WiremockTestServer.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/WiremockTestServer.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.it
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatestplus.mockito.MockitoSugar
+
+trait WiremockTestServer
+    extends AnyWordSpec with Matchers with MockitoSugar with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  val wireHost = "localhost"
+
+  val wirePort       = 20202
+  val wireMockServer = new WireMockServer(wirePort)
+
+  protected def stubFor(mappingBuilder: MappingBuilder): StubMapping =
+    wireMockServer.stubFor(mappingBuilder)
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/config/AppConfigSpec.scala
@@ -34,6 +34,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         |microservice.services.auth.port=9988
         |microservice.metrics.graphite.host=graphite
         |auditing.enabled=true
+        |eis.environment=ist0
     """.stripMargin)
 
   private val validServicesConfiguration = Configuration(validAppConfig)

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/controllers/SubscriptionControllerSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.controllers
+
+import com.codahale.metrics.SharedMetricRegistries
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.BDDMockito.`given`
+import org.mockito.Mockito.{reset, verifyNoInteractions}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json.toJson
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{route, status, _}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.SubscriptionsConnector
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.AuthTestSupport
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models.SubscriptionTestData
+
+import scala.concurrent.Future
+
+class SubscriptionControllerSpec
+    extends AnyWordSpec with GuiceOneAppPerSuite with BeforeAndAfterEach with ScalaFutures with Matchers
+    with AuthTestSupport with SubscriptionTestData {
+
+  SharedMetricRegistries.clear()
+
+  override lazy val app: Application = GuiceApplicationBuilder()
+    .overrides(bind[AuthConnector].to(mockAuthConnector), bind[SubscriptionsConnector].to(subscriptionsConnector))
+    .build()
+
+  private val subscriptionsConnector: SubscriptionsConnector = mock[SubscriptionsConnector]
+
+  private def getRequest(pptReference: String) = FakeRequest("GET", s"/subscriptions/$pptReference")
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockAuthConnector)
+    reset(subscriptionsConnector)
+  }
+
+  "GET subscription" should {
+
+    "return 200" when {
+      "request for uk limited company subscription is valid" in {
+        withAuthorizedUser()
+        val ltdSubscription = ukLimitedCompanyPptSubscription(pptReference)
+        given(subscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).willReturn(
+          Future.successful(Right(ltdSubscription))
+        )
+
+        val result: Future[Result] = route(app, getRequest(pptReference)).get
+
+        status(result) must be(OK)
+        contentAsJson(result) mustBe toJson(ltdSubscription)
+      }
+    }
+
+    "return 200" when {
+      "request for sole trader subscription is valid" in {
+        withAuthorizedUser()
+        val soleTraderSubscription = soleTraderPptSubscription(pptReference)
+        given(subscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).willReturn(
+          Future.successful(Right(soleTraderSubscription))
+        )
+
+        val result: Future[Result] = route(app, getRequest(pptReference)).get
+
+        status(result) must be(OK)
+        contentAsJson(result) mustBe toJson(soleTraderSubscription)
+      }
+    }
+
+    "return 404" when {
+      "registration not found" in {
+        withAuthorizedUser()
+        given(subscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).willReturn(
+          Future.successful(Left(404))
+        )
+
+        val result: Future[Result] = route(app, getRequest(pptReference)).get
+
+        status(result) mustBe NOT_FOUND
+      }
+    }
+
+    "return 401" when {
+      "unauthorized" in {
+        withUnauthorizedUser(new RuntimeException())
+
+        val result: Future[Result] = route(app, getRequest(pptReference)).get
+
+        status(result) must be(UNAUTHORIZED)
+        verifyNoInteractions(subscriptionsConnector)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/SubscriptionTestData.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models
+
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription._
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.{
+  ChangeOfCircumstanceDetails,
+  SubscriptionDisplayResponse
+}
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.registration._
+
+import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime.now
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+trait SubscriptionTestData {
+
+  protected def ukLimitedCompanyPptSubscription(pptReference: String = UUID.randomUUID().toString): PptSubscription =
+    PptSubscription(pptReference = pptReference,
+                    primaryContactDetails =
+                      uk.gov.hmrc.plasticpackagingtaxreturns.models.registration.PrimaryContactDetails(
+                        Some("FirstName LastName"),
+                        jobTitle = Some("CEO"),
+                        email =
+                          Some("test@test.com"),
+                        phoneNumber =
+                          Some("1234567890"),
+                        address = Some(
+                          Address(addressLine1 =
+                                    "addressLine1",
+                                  addressLine2 =
+                                    "line2",
+                                  addressLine3 =
+                                    Some("Town"),
+                                  postCode =
+                                    Some("PostCode")
+                          )
+                        )
+                      ),
+                    organisationDetails =
+                      uk.gov.hmrc.plasticpackagingtaxreturns.models.registration.OrganisationDetails(isBasedInUk =
+                                                                                                       Some(true),
+                                                                                                     organisationType =
+                                                                                                       Some(
+                                                                                                         "UK_COMPANY"
+                                                                                                       ),
+                                                                                                     businessRegisteredAddress =
+                                                                                                       Some(
+                                                                                                         Address(
+                                                                                                           addressLine1 =
+                                                                                                             "addressLine1",
+                                                                                                           addressLine3 =
+                                                                                                             Some(
+                                                                                                               "Town"
+                                                                                                             ),
+                                                                                                           addressLine2 =
+                                                                                                             "line2",
+                                                                                                           postCode =
+                                                                                                             Some(
+                                                                                                               "PostCode"
+                                                                                                             )
+                                                                                                         )
+                                                                                                       ),
+                                                                                                     safeNumber =
+                                                                                                       Some("123"),
+                                                                                                     incorporationDetails =
+                                                                                                       Some(
+                                                                                                         IncorporationDetails(
+                                                                                                           companyName =
+                                                                                                             Some(
+                                                                                                               "Plastics Limited"
+                                                                                                             ),
+                                                                                                           phoneNumber =
+                                                                                                             Some(
+                                                                                                               "077665544"
+                                                                                                             ),
+                                                                                                           email = Some(
+                                                                                                             "email@gmail.com"
+                                                                                                           )
+                                                                                                         )
+                                                                                                       )
+                      )
+    )
+
+  def soleTraderPptSubscription(pptReference: String = UUID.randomUUID().toString): PptSubscription = {
+    val regDetails = ukLimitedCompanyPptSubscription(pptReference)
+    regDetails.copy(organisationDetails =
+      regDetails.organisationDetails.copy(
+        soleTraderDetails =
+          Some(SoleTraderIncorporationDetails(firstName = Some("James"), lastName = Some("Bond"))),
+        incorporationDetails = None
+      )
+    )
+  }
+
+  protected val ukLimitedCompanySubscription: Subscription = Subscription(
+    legalEntityDetails =
+      LegalEntityDetails(dateOfApplication =
+                           now(UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                         customerIdentification1 = "123456789",
+                         customerIdentification2 = Some("1234567890"),
+                         customerDetails = CustomerDetails(customerType = CustomerType.Organisation,
+                                                           organisationDetails =
+                                                             Some(
+                                                               subscription.OrganisationDetails(
+                                                                 organisationName = Some("Plastics Ltd"),
+                                                                 organisationType = Some("UK Limited Company")
+                                                               )
+                                                             )
+                         )
+      ),
+    principalPlaceOfBusinessDetails =
+      PrincipalPlaceOfBusinessDetails(
+        addressDetails = AddressDetails(addressLine1 = "2-3 Scala Street",
+                                        addressLine2 = "London",
+                                        postalCode = Some("W1T 2HN"),
+                                        countryCode = "GB"
+        ),
+        contactDetails = ContactDetails(email = "test@test.com", telephone = "02034567890")
+      ),
+    primaryContactDetails =
+      uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.PrimaryContactDetails(
+        name = "Kevin Durant",
+        contactDetails =
+          ContactDetails(email = "test@test.com", telephone = "02034567890"),
+        positionInCompany = "Director"
+      ),
+    businessCorrespondenceDetails = BusinessCorrespondenceDetails(addressLine1 = "2-3 Scala Street",
+                                                                  addressLine2 = "London",
+                                                                  postalCode = Some("W1T 2HN"),
+                                                                  countryCode = "GB"
+    ),
+    taxObligationStartDate = now(UTC).toString,
+    last12MonthTotalTonnageAmt = Some(15000),
+    declaration = Declaration(declarationBox1 = true),
+    groupSubscription = None
+  )
+
+  protected val soleTraderSubscription: Subscription = {
+    val subscription = ukLimitedCompanySubscription.copy(legalEntityDetails =
+      LegalEntityDetails(dateOfApplication =
+                           now(UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                         customerIdentification1 = "123456789",
+                         customerIdentification2 = Some("1234567890"),
+                         customerDetails =
+                           CustomerDetails(
+                             customerType = CustomerType.Individual,
+                             individualDetails =
+                               Some(IndividualDetails(title = Some("MR"), firstName = "James", lastName = "Bond"))
+                           )
+      )
+    )
+    subscription
+  }
+
+  protected def createSubscriptionDisplayResponse(subscription: Subscription) =
+    SubscriptionDisplayResponse(processingDate = "2020-05-05",
+                                changeOfCircumstanceDetails =
+                                  ChangeOfCircumstanceDetails(changeOfCircumstance =
+                                    "update"
+                                  ),
+                                legalEntityDetails =
+                                  subscription.legalEntityDetails,
+                                principalPlaceOfBusinessDetails =
+                                  subscription.principalPlaceOfBusinessDetails,
+                                primaryContactDetails =
+                                  subscription.primaryContactDetails,
+                                businessCorrespondenceDetails =
+                                  subscription.businessCorrespondenceDetails,
+                                taxObligationStartDate =
+                                  subscription.taxObligationStartDate,
+                                last12MonthTotalTonnageAmt =
+                                  subscription.last12MonthTotalTonnageAmt.map(_.toLong),
+                                declaration =
+                                  subscription.declaration,
+                                groupSubscription =
+                                  subscription.groupSubscription
+    )
+
+}


### PR DESCRIPTION
I've created registrationDetails object to contain only strings. This way we'll display the data with same format as data coming from EIS. If we'll require to map data to our registrations model (to have same types as registrations journey), then there are few questions to answer, such as: format of dates?  address mapping? etc. 