### PR TITLE
PPTP-1011 Added audit event for subscrpition update

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/Auditor.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/Auditor.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.audit
+
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate.SubscriptionUpdateRequest
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class Auditor @Inject() (auditConnector: AuditConnector) {
+
+  def subscriptionUpdated(
+    subscriptionUpdateRequest: SubscriptionUpdateRequest,
+    pptReference: Option[String] = None
+  )(implicit hc: HeaderCarrier, ex: ExecutionContext) =
+    auditConnector.sendExplicitAudit(ChangeSubscriptionEvent.eventType,
+                                     ChangeSubscriptionEvent(subscriptionUpdateRequest, pptReference)
+    )
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/ChangeSubscriptionEvent.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/ChangeSubscriptionEvent.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.audit
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group.GroupSubscription
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.{
+  BusinessCorrespondenceDetails,
+  Declaration,
+  LegalEntityDetails,
+  PrimaryContactDetails,
+  PrincipalPlaceOfBusinessDetails
+}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.ChangeOfCircumstanceDetails
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate.SubscriptionUpdateRequest
+
+case class ChangeSubscriptionEvent(
+  changeOfCircumstanceDetails: ChangeOfCircumstanceDetails,
+  legalEntityDetails: LegalEntityDetails,
+  principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
+  primaryContactDetails: PrimaryContactDetails,
+  businessCorrespondenceDetails: BusinessCorrespondenceDetails,
+  taxObligationStartDate: String,
+  last12MonthTotalTonnageAmt: Option[BigDecimal],
+  declaration: Declaration,
+  groupSubscription: Option[GroupSubscription],
+  pptReference: Option[String]
+)
+
+object ChangeSubscriptionEvent {
+
+  implicit val format: OFormat[ChangeSubscriptionEvent] = Json.format[ChangeSubscriptionEvent]
+  val eventType: String                                 = "CHANGE_PPT_REGISTRATION"
+
+  def apply(
+    subscriptionUpdateRequest: SubscriptionUpdateRequest,
+    pptReference: Option[String]
+  ): ChangeSubscriptionEvent =
+    ChangeSubscriptionEvent(changeOfCircumstanceDetails = subscriptionUpdateRequest.changeOfCircumstanceDetails,
+                            legalEntityDetails = subscriptionUpdateRequest.legalEntityDetails,
+                            principalPlaceOfBusinessDetails = subscriptionUpdateRequest.principalPlaceOfBusinessDetails,
+                            primaryContactDetails = subscriptionUpdateRequest.primaryContactDetails,
+                            businessCorrespondenceDetails = subscriptionUpdateRequest.businessCorrespondenceDetails,
+                            taxObligationStartDate = subscriptionUpdateRequest.taxObligationStartDate,
+                            last12MonthTotalTonnageAmt = subscriptionUpdateRequest.last12MonthTotalTonnageAmt,
+                            declaration = subscriptionUpdateRequest.declaration,
+                            groupSubscription = subscriptionUpdateRequest.groupSubscription,
+                            pptReference = pptReference
+    )
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     , "metrics\\..*"
     , ".*(BuildInfo|Routes|Options).*"
   ).mkString(";"),
-  coverageMinimum := 93,
+  coverageMinimum := 97,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/auditor/AuditorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/auditor/AuditorSpec.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.auditor
+
+import com.github.tomakehurst.wiremock.client.{VerificationException, WireMock}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  aResponse,
+  equalToJson,
+  post,
+  postRequestedFor,
+  urlEqualTo,
+  verify
+}
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
+import play.api.http.Status
+import uk.gov.hmrc.plasticpackagingtaxreturns.audit.{Auditor, ChangeSubscriptionEvent}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.ChangeOfCircumstanceDetails
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate.SubscriptionUpdateRequest
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.it.{ConnectorISpec, Injector}
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models.SubscriptionTestData
+
+class AuditorSpec extends ConnectorISpec with Injector with ScalaFutures with SubscriptionTestData {
+
+  val auditor: Auditor = app.injector.instanceOf[Auditor]
+  val auditUrl         = "/write/audit"
+
+  override def overrideConfig: Map[String, Any] =
+    Map("auditing.enabled" -> true, "auditing.consumer.baseUri.port" -> wirePort)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    WireMock.configureFor(wireHost, wirePort)
+    wireMockServer.start()
+  }
+
+  override protected def afterAll(): Unit = {
+    wireMockServer.stop()
+    super.afterAll()
+  }
+
+  "Auditor" should {
+    "post registration change event" when {
+      "subscriptionUpdate invoked" in {
+        givenAuditReturns(Status.NO_CONTENT)
+        val subscriptionUpdateRequest =
+          createSubscriptionUpdateResponse(ukLimitedCompanySubscription, ChangeOfCircumstanceDetails("Update details"))
+
+        auditor.subscriptionUpdated(subscriptionUpdateRequest, pptReference = Some("pptReference"))
+
+        eventually(timeout(Span(5, Seconds))) {
+          eventSendToAudit(auditUrl, subscriptionUpdateRequest) mustBe true
+        }
+      }
+    }
+
+    "not throw exception" when {
+      "submit registration audit event fails" in {
+        givenAuditReturns(Status.BAD_REQUEST)
+        val subscriptionUpdateRequest =
+          createSubscriptionUpdateResponse(ukLimitedCompanySubscription, ChangeOfCircumstanceDetails("Update details"))
+
+        auditor.subscriptionUpdated(subscriptionUpdateRequest)
+
+        eventually(timeout(Span(5, Seconds))) {
+          eventSendToAudit(auditUrl, subscriptionUpdateRequest) mustBe true
+        }
+      }
+    }
+
+  }
+
+  private def givenAuditReturns(statusCode: Int): Unit =
+    stubFor(
+      post(auditUrl)
+        .willReturn(
+          aResponse()
+            .withStatus(statusCode)
+        )
+    )
+
+  private def eventSendToAudit(url: String, subscriptionUpdateRequest: SubscriptionUpdateRequest): Boolean =
+    eventSendToAudit(url,
+                     ChangeSubscriptionEvent.eventType,
+                     SubscriptionUpdateRequest.format.writes(subscriptionUpdateRequest).toString()
+    )
+
+  private def eventSendToAudit(url: String, eventType: String, body: String): Boolean =
+    try {
+      verify(
+        postRequestedFor(urlEqualTo(url))
+          .withRequestBody(equalToJson(s"""{
+                                          |                  "auditSource": "plastic-packaging-tax-returns",
+                                          |                  "auditType": "$eventType",
+                                          |                  "eventId": "$${json-unit.any-string}",
+                                          |                  "tags": {
+                                          |                    "clientIP": "-",
+                                          |                    "path": "-",
+                                          |                    "X-Session-ID": "-",
+                                          |                    "Akamai-Reputation": "-",
+                                          |                    "X-Request-ID": "-",
+                                          |                    "deviceID": "-",
+                                          |                    "clientPort": "-"
+                                          |                  },
+                                          |                  "detail": $body,
+                                          |                  "generatedAt": "$${json-unit.any-string}",
+                                          |                  "metadata": {
+                                          |                    "sendAttemptAt": "$${json-unit.any-string}",
+                                          |                    "instanceID": "$${json-unit.any-string}",
+                                          |                    "sequence": "$${json-unit.any-number}"
+                                          |                  }
+                                          |                }""".stripMargin, true, true))
+      )
+      true
+    } catch {
+      case _: VerificationException => false
+    }
+
+}


### PR DESCRIPTION
- Added audit event for subscriptionUpdate - event type - CHANGE_PPT_REGISTRATION
- Audit event has the subscriptionUpdateRequest payload and pptReference as part of auditing



Brief description of what/why/how.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
