### PR TITLE
PPTP-1010 Added Nrs details to audit on subscription update

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/Auditor.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/Auditor.scala
@@ -17,9 +17,10 @@
 package uk.gov.hmrc.plasticpackagingtaxreturns.audit
 
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate.SubscriptionUpdateRequest
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.Subscription
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
+import java.time.ZonedDateTime
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
@@ -27,11 +28,12 @@ import scala.concurrent.ExecutionContext
 class Auditor @Inject() (auditConnector: AuditConnector) {
 
   def subscriptionUpdated(
-    subscriptionUpdateRequest: SubscriptionUpdateRequest,
-    pptReference: Option[String] = None
-  )(implicit hc: HeaderCarrier, ex: ExecutionContext) =
+    subscription: Subscription,
+    pptReference: Option[String] = None,
+    processingDateTime: Option[ZonedDateTime] = None
+  )(implicit hc: HeaderCarrier, ex: ExecutionContext): Unit =
     auditConnector.sendExplicitAudit(ChangeSubscriptionEvent.eventType,
-                                     ChangeSubscriptionEvent(subscriptionUpdateRequest, pptReference)
+                                     ChangeSubscriptionEvent(subscription, pptReference, processingDateTime)
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/ChangeSubscriptionEvent.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/audit/ChangeSubscriptionEvent.scala
@@ -18,18 +18,13 @@ package uk.gov.hmrc.plasticpackagingtaxreturns.audit
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group.GroupSubscription
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.{
-  BusinessCorrespondenceDetails,
-  Declaration,
-  LegalEntityDetails,
-  PrimaryContactDetails,
-  PrincipalPlaceOfBusinessDetails
-}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription._
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.ChangeOfCircumstanceDetails
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate.SubscriptionUpdateRequest
+
+import java.time.ZonedDateTime
 
 case class ChangeSubscriptionEvent(
-  changeOfCircumstanceDetails: ChangeOfCircumstanceDetails,
+  changeOfCircumstanceDetails: Option[ChangeOfCircumstanceDetails],
   legalEntityDetails: LegalEntityDetails,
   principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
   primaryContactDetails: PrimaryContactDetails,
@@ -38,7 +33,8 @@ case class ChangeSubscriptionEvent(
   last12MonthTotalTonnageAmt: Option[BigDecimal],
   declaration: Declaration,
   groupSubscription: Option[GroupSubscription],
-  pptReference: Option[String]
+  pptReference: Option[String],
+  processingDateTime: Option[ZonedDateTime]
 )
 
 object ChangeSubscriptionEvent {
@@ -47,19 +43,22 @@ object ChangeSubscriptionEvent {
   val eventType: String                                 = "CHANGE_PPT_REGISTRATION"
 
   def apply(
-    subscriptionUpdateRequest: SubscriptionUpdateRequest,
-    pptReference: Option[String]
+    subscription: Subscription,
+    pptReference: Option[String],
+    processingDateTime: Option[ZonedDateTime]
   ): ChangeSubscriptionEvent =
-    ChangeSubscriptionEvent(changeOfCircumstanceDetails = subscriptionUpdateRequest.changeOfCircumstanceDetails,
-                            legalEntityDetails = subscriptionUpdateRequest.legalEntityDetails,
-                            principalPlaceOfBusinessDetails = subscriptionUpdateRequest.principalPlaceOfBusinessDetails,
-                            primaryContactDetails = subscriptionUpdateRequest.primaryContactDetails,
-                            businessCorrespondenceDetails = subscriptionUpdateRequest.businessCorrespondenceDetails,
-                            taxObligationStartDate = subscriptionUpdateRequest.taxObligationStartDate,
-                            last12MonthTotalTonnageAmt = subscriptionUpdateRequest.last12MonthTotalTonnageAmt,
-                            declaration = subscriptionUpdateRequest.declaration,
-                            groupSubscription = subscriptionUpdateRequest.groupSubscription,
-                            pptReference = pptReference
+    ChangeSubscriptionEvent(changeOfCircumstanceDetails = subscription.changeOfCircumstanceDetails,
+                            legalEntityDetails = subscription.legalEntityDetails,
+                            principalPlaceOfBusinessDetails = subscription.principalPlaceOfBusinessDetails,
+                            primaryContactDetails = subscription.primaryContactDetails,
+                            businessCorrespondenceDetails = subscription.businessCorrespondenceDetails,
+                            taxObligationStartDate = subscription.taxObligationStartDate,
+                            last12MonthTotalTonnageAmt =
+                              Some(BigDecimal(subscription.last12MonthTotalTonnageAmt.getOrElse(0).toString)),
+                            declaration = subscription.declaration,
+                            groupSubscription = subscription.groupSubscription,
+                            pptReference = pptReference,
+                            processingDateTime = processingDateTime
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/config/AppConfig.scala
@@ -20,10 +20,13 @@ import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.FiniteDuration
 
 @Singleton
 class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig) {
+
   lazy val eisHost: String = servicesConfig.baseUrl("eis")
+  lazy val nrsHost: String = servicesConfig.baseUrl("nrs")
 
   def subscriptionDisplayUrl(pptReference: String): String =
     s"$eisHost/plastic-packaging-tax/subscriptions/PPT/$pptReference/display"
@@ -40,4 +43,11 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val eisEnvironment: String = config.get[String]("eis.environment")
 
   val bearerToken: String = s"Bearer ${config.get[String]("microservice.services.eis.bearerToken")}"
+
+  lazy val nonRepudiationSubmissionUrl: String = s"${nrsHost}/submission"
+
+  lazy val nonRepudiationApiKey: String =
+    servicesConfig.getString("microservice.services.nrs.api-key")
+
+  val nrsRetries: Seq[FiniteDuration] = config.get[Seq[FiniteDuration]]("nrs.retries")
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/NonRepudiationConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/NonRepudiationConnector.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors
+
+import akka.actor.ActorSystem
+import com.codahale.metrics.Timer
+import com.kenshoo.play.metrics.Metrics
+import play.api.http.Status.ACCEPTED
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpException, HttpReadsHttpResponse, HttpResponse}
+import uk.gov.hmrc.plasticpackagingtaxreturns.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.{
+  NonRepudiationMetadata,
+  NonRepudiationSubmissionAccepted
+}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Try}
+import uk.gov.hmrc.plasticpackagingtaxreturns.util.Retry
+
+@Singleton
+class NonRepudiationConnector @Inject() (
+  httpClient: HttpClient,
+  val config: AppConfig,
+  metrics: Metrics,
+  override val actorSystem: ActorSystem
+)(implicit ec: ExecutionContext)
+    extends HttpReadsHttpResponse with Retry {
+
+  def submitNonRepudiation(encodedPayloadString: String, nonRepudiationMetadata: NonRepudiationMetadata)(implicit
+    hc: HeaderCarrier
+  ): Future[NonRepudiationSubmissionAccepted] = {
+    val timer    = metrics.defaultRegistry.timer("ppt.nrs.submission.timer").time()
+    val jsonBody = Json.obj("payload" -> encodedPayloadString, "metadata" -> nonRepudiationMetadata)
+
+    retry(config.nrsRetries: _*)(shouldRetry, reasonForRetrying[NonRepudiationSubmissionAccepted]) {
+      submit(timer, jsonBody)
+    }
+  }
+
+  private def submit(timer: Timer.Context, jsonBody: JsObject)(implicit
+    hc: HeaderCarrier
+  ): Future[NonRepudiationSubmissionAccepted] =
+    httpClient.POST[JsObject, HttpResponse](url = config.nonRepudiationSubmissionUrl,
+                                            body = jsonBody,
+                                            headers =
+                                              Seq("X-API-Key" -> config.nonRepudiationApiKey)
+    ).andThen { case _ => timer.stop() }
+      .map {
+        response =>
+          response.status match {
+            case ACCEPTED =>
+              val submissionId = (response.json \ "nrSubmissionId").as[String]
+              NonRepudiationSubmissionAccepted(submissionId)
+            case _ =>
+              throw new HttpException(response.body, response.status)
+          }
+      }
+
+  private def shouldRetry[A](response: Try[A]): Boolean =
+    response match {
+      case Failure(e) if e.asInstanceOf[HttpException].responseCode == 500 => true
+      // TODO: are there any other failure scenarios in which we would want to retry?
+      case _ => false
+    }
+
+  private def reasonForRetrying[A](response: Try[A]): String =
+    response match {
+      case _ => "Non Repudiation Service submission failed"
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/Subscription.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscription/Subscription.scala
@@ -18,8 +18,11 @@ package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptio
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription.group.GroupSubscription
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.ChangeOfCircumstanceDetails
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.NrsDetails
 
 case class Subscription(
+  changeOfCircumstanceDetails: Option[ChangeOfCircumstanceDetails] = None,
   legalEntityDetails: LegalEntityDetails,
   principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
   primaryContactDetails: PrimaryContactDetails,
@@ -27,7 +30,8 @@ case class Subscription(
   declaration: Declaration,
   taxObligationStartDate: String,
   last12MonthTotalTonnageAmt: Option[Long] = None,
-  groupSubscription: Option[GroupSubscription] = None
+  groupSubscription: Option[GroupSubscription] = None,
+  nrsDetails: Option[NrsDetails] = None
 )
 
 object Subscription {

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/EISResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/EISResponse.scala
@@ -16,4 +16,4 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
 
-trait SubscriptionUpdateResponse
+trait EISResponse

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/EISSubscriptionUpdateSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/EISSubscriptionUpdateSuccessfulResponse.scala
@@ -16,4 +16,11 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
 
-trait SubscriptionUpdateResponse
+import java.time.ZonedDateTime
+
+trait EISSubscriptionUpdateSuccessfulResponse extends EISResponse {
+
+  val pptReference: String
+  val processingDate: ZonedDateTime
+  val formBundleNumber: String
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateRequest.scala
@@ -30,8 +30,23 @@ case class SubscriptionUpdateRequest(
   taxObligationStartDate: String,
   last12MonthTotalTonnageAmt: Option[BigDecimal],
   declaration: Declaration,
-  groupSubscription: Option[GroupSubscription]
-)
+  groupSubscription: Option[GroupSubscription],
+  userHeaders: Option[Map[String, String]] = None
+) {
+
+  def toSubscription: Subscription =
+    Subscription(changeOfCircumstanceDetails = Some(this.changeOfCircumstanceDetails),
+                 legalEntityDetails = this.legalEntityDetails,
+                 principalPlaceOfBusinessDetails = this.principalPlaceOfBusinessDetails,
+                 primaryContactDetails = this.primaryContactDetails,
+                 businessCorrespondenceDetails = this.businessCorrespondenceDetails,
+                 declaration = this.declaration,
+                 taxObligationStartDate = this.taxObligationStartDate,
+                 last12MonthTotalTonnageAmt = Some(this.last12MonthTotalTonnageAmt.getOrElse(BigDecimal(0)).toLong),
+                 groupSubscription = this.groupSubscription
+    )
+
+}
 
 object SubscriptionUpdateRequest {
   implicit val format: OFormat[SubscriptionUpdateRequest] = Json.format[SubscriptionUpdateRequest]

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateSuccessfulResponse.scala
@@ -16,4 +16,19 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
 
-trait SubscriptionUpdateResponse
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.ZonedDateTime
+
+case class SubscriptionUpdateSuccessfulResponse(
+  pptReference: String,
+  processingDate: ZonedDateTime,
+  formBundleNumber: String
+) extends SubscriptionUpdateResponse
+
+object SubscriptionUpdateSuccessfulResponse {
+
+  implicit val format: OFormat[SubscriptionUpdateSuccessfulResponse] =
+    Json.format[SubscriptionUpdateSuccessfulResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateWithNrsFailureResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateWithNrsFailureResponse.scala
@@ -16,4 +16,21 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
 
-trait SubscriptionUpdateResponse
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.nonRepudiation.NrsFailureResponse
+
+import java.time.ZonedDateTime
+
+case class SubscriptionUpdateWithNrsFailureResponse(
+  override val pptReference: String,
+  override val processingDate: ZonedDateTime,
+  override val formBundleNumber: String,
+  override val nrsFailureReason: String
+) extends EISSubscriptionUpdateSuccessfulResponse with NrsFailureResponse
+
+object SubscriptionUpdateWithNrsFailureResponse {
+
+  implicit val format: OFormat[SubscriptionUpdateWithNrsFailureResponse] =
+    Json.format[SubscriptionUpdateWithNrsFailureResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateWithNrsSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateWithNrsSuccessfulResponse.scala
@@ -16,4 +16,21 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
 
-trait SubscriptionUpdateResponse
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.nonRepudiation.NrsSuccessfulResponse
+
+import java.time.ZonedDateTime
+
+case class SubscriptionUpdateWithNrsSuccessfulResponse(
+  override val pptReference: String,
+  override val processingDate: ZonedDateTime,
+  override val formBundleNumber: String,
+  override val nrSubmissionId: String
+) extends EISSubscriptionUpdateSuccessfulResponse with NrsSuccessfulResponse
+
+object SubscriptionUpdateWithNrsSuccessfulResponse {
+
+  implicit val format: OFormat[SubscriptionUpdateWithNrsSuccessfulResponse] =
+    Json.format[SubscriptionUpdateWithNrsSuccessfulResponse]
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/nonRepudiation/NrsFailureResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/nonRepudiation/NrsFailureResponse.scala
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.nonRepudiation
 
-trait SubscriptionUpdateResponse
+trait NrsFailureResponse extends NrsResponse {
+  val nrsFailureReason: String
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/nonRepudiation/NrsResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/nonRepudiation/NrsResponse.scala
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.nonRepudiation
 
-trait SubscriptionUpdateResponse
+trait NrsResponse

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/nonRepudiation/NrsSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/nonRepudiation/NrsSuccessfulResponse.scala
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.nonRepudiation
 
-trait SubscriptionUpdateResponse
+trait NrsSuccessfulResponse extends NrsResponse {
+  val nrSubmissionId: String
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/IdentityData.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/IdentityData.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation
+
+import org.joda.time.{DateTime, LocalDate}
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.auth.core.retrieve._
+import uk.gov.hmrc.auth.core.{AffinityGroup, ConfidenceLevel, CredentialRole}
+import uk.gov.hmrc.http.controllers.RestFormats
+
+case class IdentityData(
+  internalId: Option[String] = None,
+  externalId: Option[String] = None,
+  agentCode: Option[String] = None,
+  optionalCredentials: Option[Credentials] = None,
+  confidenceLevel: ConfidenceLevel,
+  nino: Option[String] = None,
+  saUtr: Option[String] = None,
+  optionalName: Option[Name] = None,
+  dateOfBirth: Option[LocalDate] = None,
+  email: Option[String] = None,
+  agentInformation: AgentInformation,
+  groupIdentifier: Option[String] = None,
+  credentialRole: Option[CredentialRole] = None,
+  mdtpInformation: Option[MdtpInformation] = None,
+  optionalItmpName: Option[ItmpName] = None,
+  itmpDateOfBirth: Option[LocalDate] = None,
+  optionalItmpAddress: Option[ItmpAddress] = None,
+  affinityGroup: Option[AffinityGroup] = None,
+  credentialStrength: Option[String] = None,
+  loginTimes: LoginTimes
+)
+
+object IdentityData {
+  implicit val localDateFormat: Format[LocalDate]         = RestFormats.localDateFormats
+  implicit val dateTimeFormat: Format[DateTime]           = RestFormats.dateTimeFormats
+  implicit val credFormat: OFormat[Credentials]           = Json.format[Credentials]
+  implicit val nameFormat: OFormat[Name]                  = Json.format[Name]
+  implicit val agentInfoFormat: OFormat[AgentInformation] = Json.format[AgentInformation]
+  implicit val mdtpInfoFormat: OFormat[MdtpInformation]   = Json.format[MdtpInformation]
+  implicit val itmpNameFormat: OFormat[ItmpName]          = Json.format[ItmpName]
+  implicit val itmpAddressFormat: OFormat[ItmpAddress]    = Json.format[ItmpAddress]
+  implicit val loginTimes: OFormat[LoginTimes]            = Json.format[LoginTimes]
+  implicit val formats: OFormat[IdentityData]             = Json.format[IdentityData]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/NonRepudiationMetaData.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/NonRepudiationMetaData.scala
@@ -14,6 +14,24 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation
 
-trait SubscriptionUpdateResponse
+import play.api.libs.json._
+
+import java.time.ZonedDateTime
+
+case class NonRepudiationMetadata(
+  businessId: String,
+  notableEvent: String,
+  payloadContentType: String,
+  payloadSha256Checksum: String,
+  userSubmissionTimestamp: ZonedDateTime,
+  identityData: IdentityData,
+  userAuthToken: String,
+  headerData: Map[String, String],
+  searchKeys: Map[String, String]
+)
+
+object NonRepudiationMetadata {
+  implicit val format: OFormat[NonRepudiationMetadata] = Json.format[NonRepudiationMetadata]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/NonRepudiationSubmissionAccepted.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/NonRepudiationSubmissionAccepted.scala
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation
 
-trait SubscriptionUpdateResponse
+import play.api.libs.json.{Json, OFormat}
+
+case class NonRepudiationSubmissionAccepted(submissionId: String)
+
+object NonRepudiationSubmissionAccepted {
+  implicit val format: OFormat[NonRepudiationMetadata] = Json.format[NonRepudiationMetadata]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/NrsDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/nonRepudiation/NrsDetails.scala
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate
+package uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation
 
-trait SubscriptionUpdateResponse
+import play.api.libs.json.{Json, OFormat}
+
+case class NrsDetails(nrsSubmissionId: Option[String] = None, failureReason: Option[String] = None)
+
+object NrsDetails {
+  implicit val format: OFormat[NrsDetails] = Json.format[NrsDetails]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/services/nonRepudiation/NonRepudiationService.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/services/nonRepudiation/NonRepudiationService.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation
+
+import org.joda.time.LocalDate
+import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector, AuthorisedFunctions, ConfidenceLevel, CredentialRole}
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.{
+  ~,
+  AgentInformation,
+  Credentials,
+  ItmpAddress,
+  ItmpName,
+  LoginTimes,
+  MdtpInformation,
+  Name,
+  Retrieval
+}
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpException, InternalServerException}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.NonRepudiationConnector
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.{
+  IdentityData,
+  NonRepudiationMetadata,
+  NonRepudiationSubmissionAccepted
+}
+import uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation.NonRepudiationService.nonRepudiationIdentityRetrievals
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.ZonedDateTime
+import java.util.Base64
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+case class NonRepudiationService @Inject() (
+  nonRepudiationConnector: NonRepudiationConnector,
+  authConnector: AuthConnector
+)(implicit ec: ExecutionContext)
+    extends AuthorisedFunctions {
+
+  def submitNonRepudiation(
+    payloadString: String,
+    submissionTimestamp: ZonedDateTime,
+    pptReference: String,
+    userHeaders: Map[String, String]
+  )(implicit hc: HeaderCarrier): Future[NonRepudiationSubmissionAccepted] =
+    for {
+      identityData <- retrieveIdentityData()
+      payloadChecksum = retrievePayloadChecksum(payloadString)
+      userAuthToken   = retrieveUserAuthToken(hc)
+      nonRepudiationMetadata = NonRepudiationMetadata("ppt",
+                                                      "ppt-subscription",
+                                                      "application/json",
+                                                      payloadChecksum,
+                                                      submissionTimestamp,
+                                                      identityData,
+                                                      userAuthToken,
+                                                      userHeaders,
+                                                      Map("pptReference" -> pptReference)
+      )
+      encodedPayloadString = encodePayload(payloadString)
+      nonRepudiationSubmissionResponse <- retrieveNonRepudiationResponse(nonRepudiationMetadata, encodedPayloadString)
+    } yield nonRepudiationSubmissionResponse
+
+  private def encodePayload(payloadString: String): String =
+    Base64.getEncoder.encodeToString(payloadString.getBytes(StandardCharsets.UTF_8))
+
+  private def retrieveNonRepudiationResponse(
+    nonRepudiationMetadata: NonRepudiationMetadata,
+    encodedPayloadString: String
+  )(implicit hc: HeaderCarrier): Future[NonRepudiationSubmissionAccepted] =
+    nonRepudiationConnector.submitNonRepudiation(encodedPayloadString, nonRepudiationMetadata).map {
+      case response @ NonRepudiationSubmissionAccepted(_) => response
+    }.recoverWith {
+      case exception: HttpException => Future.failed(exception)
+    }
+
+  private def retrieveUserAuthToken(hc: HeaderCarrier): String =
+    hc.authorization match {
+      case Some(Authorization(authToken)) => authToken
+      case _                              => throw new InternalServerException("No auth token available for NRS")
+    }
+
+  private def retrievePayloadChecksum(payloadString: String): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(payloadString.getBytes(StandardCharsets.UTF_8))
+      .map("%02x".format(_)).mkString
+
+  private def retrieveIdentityData()(implicit headerCarrier: HeaderCarrier): Future[IdentityData] =
+    authConnector.authorise(EmptyPredicate, nonRepudiationIdentityRetrievals).map {
+      case affinityGroup ~ internalId ~
+          externalId ~ agentCode ~
+          credentials ~ confidenceLevel ~
+          nino ~ saUtr ~
+          name ~ dateOfBirth ~
+          email ~ agentInfo ~
+          groupId ~ credentialRole ~
+          mdtpInfo ~ itmpName ~
+          itmpDateOfBirth ~ itmpAddress ~
+          credentialStrength ~ loginTimes =>
+        IdentityData(internalId = internalId,
+                     externalId = externalId,
+                     agentCode = agentCode,
+                     optionalCredentials = credentials,
+                     confidenceLevel = confidenceLevel,
+                     nino = nino,
+                     saUtr = saUtr,
+                     optionalName = name,
+                     dateOfBirth = dateOfBirth,
+                     email = email,
+                     agentInformation = agentInfo,
+                     groupIdentifier = groupId,
+                     credentialRole = credentialRole,
+                     mdtpInformation = mdtpInfo,
+                     optionalItmpName = itmpName,
+                     itmpDateOfBirth = itmpDateOfBirth,
+                     optionalItmpAddress = itmpAddress,
+                     affinityGroup = affinityGroup,
+                     credentialStrength = credentialStrength,
+                     loginTimes = loginTimes
+        )
+    }
+
+}
+
+object NonRepudiationService {
+
+  type NonRepudiationIdentityRetrievals =
+    (Option[AffinityGroup] ~ Option[String]
+      ~ Option[String] ~ Option[String]
+      ~ Option[Credentials] ~ ConfidenceLevel
+      ~ Option[String] ~ Option[String]
+      ~ Option[Name] ~ Option[LocalDate]
+      ~ Option[String] ~ AgentInformation
+      ~ Option[String] ~ Option[CredentialRole]
+      ~ Option[MdtpInformation] ~ Option[ItmpName]
+      ~ Option[LocalDate] ~ Option[ItmpAddress]
+      ~ Option[String] ~ LoginTimes)
+
+  val nonRepudiationIdentityRetrievals: Retrieval[NonRepudiationIdentityRetrievals] =
+    Retrievals.affinityGroup and Retrievals.internalId and
+      Retrievals.externalId and Retrievals.agentCode and
+      Retrievals.credentials and Retrievals.confidenceLevel and
+      Retrievals.nino and Retrievals.saUtr and
+      Retrievals.name and Retrievals.dateOfBirth and
+      Retrievals.email and Retrievals.agentInformation and
+      Retrievals.groupIdentifier and Retrievals.credentialRole and
+      Retrievals.mdtpInformation and Retrievals.itmpName and
+      Retrievals.itmpDateOfBirth and Retrievals.itmpAddress and
+      Retrievals.credentialStrength and Retrievals.loginTimes
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/util/Retry.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/util/Retry.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.util
+
+import akka.actor.ActorSystem
+import akka.pattern.after
+import play.api.Logger
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+trait Retry {
+  private val logger = Logger(getClass)
+  implicit protected def actorSystem: ActorSystem
+
+  def retry[A](intervals: FiniteDuration*)(shouldRetry: Try[A] => Boolean, retryReason: Try[A] => String)(
+    block: => Future[A]
+  )(implicit ec: ExecutionContext): Future[A] = {
+    def loop(remainingIntervals: Seq[FiniteDuration])(block: => Future[A]): Future[A] =
+      block.flatMap(
+        result =>
+          if (remainingIntervals.nonEmpty && shouldRetry(Success(result))) {
+            val delay = remainingIntervals.head
+            logger.warn(s"Retrying in $delay due to ${retryReason(Success(result))}")
+            after(delay, actorSystem.scheduler)(loop(remainingIntervals.tail)(block))
+          } else {
+            logger.info("Success!")
+            Future.successful(result)
+          }
+      )
+        .recoverWith {
+          case e: Throwable =>
+            if (remainingIntervals.nonEmpty && shouldRetry(Failure(e))) {
+              val delay = remainingIntervals.head
+              logger.warn(s"Retrying in $delay due to ${retryReason(Failure(e))}")
+              after(delay, actorSystem.scheduler)(loop(remainingIntervals.tail)(block))
+            } else
+              Future.failed(e)
+        }
+    loop(intervals)(block)
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -140,7 +140,17 @@ microservice {
       bearerToken = "test123456"
       url = "http://localhost:8506"
     }
+
+    nrs {
+      api-key = "test-key"
+      host = localhost
+      port = 8506
+      url = "http://localhost:8506"
+    }
   }
 }
 
 eis.environment = "ist0"
+
+# Defines the number and individual backoff delays for NRS submission retries
+nrs.retries = ["1s", "2s", "4s"]

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/NonRepudiationConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/NonRepudiationConnectorISpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatest.concurrent.ScalaFutures
+import play.api.http.Status.{ACCEPTED, INTERNAL_SERVER_ERROR}
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.test.Helpers.await
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.AuthTestSupport
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.it.{ConnectorISpec, Injector}
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models.NrsTestData
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.{
+  NonRepudiationMetadata,
+  NonRepudiationSubmissionAccepted
+}
+
+class NonRepudiationConnectorISpec
+    extends ConnectorISpec with Injector with AuthTestSupport with NrsTestData with ScalaFutures {
+  lazy val config                                       = Map("microservice.services.nrs.api-key" -> testNonRepudiationApiKey)
+  lazy val connector: NonRepudiationConnector           = app.injector.instanceOf[NonRepudiationConnector]
+  private implicit val testNonRepudiationApiKey: String = "test-key"
+
+  private val pptNrsSubmissionTimer = "ppt.nrs.submission.timer"
+
+  "submitNonRepudiation" should {
+    val testEncodedPayload  = "testEncodedPayload"
+    val testPayloadChecksum = "testPayloadChecksum"
+    val headerData          = Map("testHeaderKey" -> "testHeaderValue")
+
+    val testNonRepudiationMetadata = NonRepudiationMetadata(businessId = "vrs",
+                                                            notableEvent = "vat-registration",
+                                                            payloadContentType =
+                                                              "application/json",
+                                                            payloadSha256Checksum =
+                                                              testPayloadChecksum,
+                                                            userSubmissionTimestamp =
+                                                              testDateTime,
+                                                            identityData =
+                                                              testNonRepudiationIdentityData,
+                                                            userAuthToken = testAuthToken,
+                                                            headerData = headerData,
+                                                            searchKeys =
+                                                              Map("postCode" -> testPPTReference)
+    )
+
+    val expectedRequestJson: JsObject =
+      Json.obj("payload" -> testEncodedPayload, "metadata" -> testNonRepudiationMetadata)
+
+    "return a success" in {
+      val testNonRepudiationSubmissionId = "testNonRepudiationSubmissionId"
+      stubNonRepudiationSubmission(ACCEPTED,
+                                   expectedRequestJson,
+                                   Json.obj("nrSubmissionId" -> testNonRepudiationSubmissionId)
+      )
+
+      val res = connector.submitNonRepudiation(testEncodedPayload, testNonRepudiationMetadata)
+
+      await(res) mustBe NonRepudiationSubmissionAccepted(testNonRepudiationSubmissionId)
+      getTimer(pptNrsSubmissionTimer).getCount mustBe 1
+    }
+
+    "throw an exception" when {
+      "nrs service fails" in {
+        stubNonRepudiationSubmissionFailure(INTERNAL_SERVER_ERROR, expectedRequestJson)
+
+        intercept[Exception] {
+          await(connector.submitNonRepudiation(testEncodedPayload, testNonRepudiationMetadata))
+        }
+        getTimer(pptNrsSubmissionTimer).getCount mustBe 4 // We have 3 retries configured
+      }
+    }
+
+    "retry" when {
+      "nrs submission fails on first attempt" in {
+        val expectedSubmissionId = "nrs-submission-id"
+        expectNRSToFailOnceAndThenSucceed(INTERNAL_SERVER_ERROR,
+                                          ACCEPTED,
+                                          expectedRequestJson,
+                                          Json.obj("nrSubmissionId" -> expectedSubmissionId)
+        )
+
+        await(connector.submitNonRepudiation(testEncodedPayload, testNonRepudiationMetadata))
+          .submissionId must be(expectedSubmissionId)
+      }
+    }
+
+  }
+
+  private def stubNonRepudiationSubmission(status: Int, request: JsValue, response: JsObject)(implicit
+    apiKey: String
+  ): StubMapping =
+    stubFor(
+      post(urlMatching(s"/submission"))
+        .withRequestBody(equalToJson(request.toString()))
+        .withHeader("X-API-Key", equalTo(apiKey))
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+            .withBody(response.toString())
+        )
+    )
+
+  private def stubNonRepudiationSubmissionFailure(status: Int, requestJson: JsValue)(implicit
+    apiKey: String
+  ): StubMapping =
+    stubFor(
+      post(urlMatching(s"/submission"))
+        .withRequestBody(equalToJson(requestJson.toString()))
+        .withHeader("X-API-Key", equalTo(apiKey))
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+        )
+    )
+
+  private def expectNRSToFailOnceAndThenSucceed(
+    failStatus: Int,
+    successStatus: Int,
+    request: JsValue,
+    response: JsObject
+  )(implicit apiKey: String): StubMapping = {
+    val scenario = "Retry Scenario"
+    stubFor(
+      post(urlMatching(s"/submission"))
+        .withRequestBody(equalToJson(request.toString()))
+        .withHeader("X-API-Key", equalTo(apiKey))
+        .inScenario(scenario)
+        .whenScenarioStateIs("Started")
+        .willReturn(
+          aResponse()
+            .withStatus(failStatus)
+        )
+        .willSetStateTo("One Failure")
+    )
+
+    stubFor(
+      post(urlMatching(s"/submission"))
+        .withRequestBody(equalToJson(request.toString()))
+        .withHeader("X-API-Key", equalTo(apiKey))
+        .inScenario(scenario)
+        .whenScenarioStateIs("One Failure")
+        .willReturn(
+          aResponse()
+            .withStatus(successStatus)
+            .withBody(response.toString())
+        )
+    )
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/AuthTestSupport.scala
@@ -18,18 +18,21 @@ package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing
 import org.mockito.{ArgumentMatcher, ArgumentMatchers}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Logger
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.allEnrolments
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name}
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name, Retrieval}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.AuthAction._
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models.SignedInUser
+import uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation.NonRepudiationService.NonRepudiationIdentityRetrievals
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait AuthTestSupport extends MockitoSugar {
 
@@ -88,5 +91,16 @@ trait AuthTestSupport extends MockitoSugar {
 
   def newEnrolment(key: String, identifierName: String, identifierValue: String): Enrolment =
     Enrolment(key).withIdentifier(identifierName, identifierValue)
+
+  def mockAuthorization(
+    nrsIdentityRetrievals: Retrieval[NonRepudiationIdentityRetrievals],
+    authRetrievalsResponse: NonRepudiationIdentityRetrievals
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): OngoingStubbing[Future[NonRepudiationIdentityRetrievals]] =
+    when(
+      mockAuthConnector.authorise(ArgumentMatchers.eq(EmptyPredicate), ArgumentMatchers.eq(nrsIdentityRetrievals))(
+        ArgumentMatchers.eq(hc),
+        ArgumentMatchers.eq(ec)
+      )
+    ).thenReturn(Future.successful(authRetrievalsResponse))
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/ConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/it/ConnectorISpec.scala
@@ -42,7 +42,11 @@ class ConnectorISpec extends WiremockTestServer with GuiceOneAppPerSuite with De
   }
 
   def overrideConfig: Map[String, Any] =
-    Map("microservice.services.eis.host" -> wireHost, "microservice.services.eis.port" -> wirePort)
+    Map("microservice.services.eis.host" -> wireHost,
+        "microservice.services.eis.port" -> wirePort,
+        "microservice.services.nrs.host" -> wireHost,
+        "microservice.services.nrs.port" -> wirePort
+    )
 
   def getTimer(name: String): Timer =
     SharedMetricRegistries

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/unit/MockConnectors.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/unit/MockConnectors.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.unit
+
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.mockito.stubbing.OngoingStubbing
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.SubscriptionDisplayResponse
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionUpdate.{
+  SubscriptionUpdateRequest,
+  SubscriptionUpdateResponse,
+  SubscriptionUpdateSuccessfulResponse
+}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.{NonRepudiationConnector, SubscriptionsConnector}
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.{
+  NonRepudiationMetadata,
+  NonRepudiationSubmissionAccepted
+}
+
+import scala.concurrent.Future
+
+trait MockConnectors extends MockitoSugar with BeforeAndAfterEach {
+  self: Suite =>
+
+  protected val mockSubscriptionsConnector: SubscriptionsConnector   = mock[SubscriptionsConnector]
+  protected val mockNonRepudiationConnector: NonRepudiationConnector = mock[NonRepudiationConnector]
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockSubscriptionsConnector, mockNonRepudiationConnector)
+  }
+
+  protected def mockGetSubscriptionFailure(
+    pptReference: String,
+    statusCode: Int
+  ): OngoingStubbing[Future[Either[Int, SubscriptionDisplayResponse]]] =
+    when(mockSubscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).thenReturn(
+      Future.successful(Left(statusCode))
+    )
+
+  protected def mockGetSubscription(
+    pptReference: String,
+    displayResponse: SubscriptionDisplayResponse
+  ): OngoingStubbing[Future[Either[Int, SubscriptionDisplayResponse]]] =
+    when(mockSubscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).thenReturn(
+      Future.successful(Right(displayResponse))
+    )
+
+  protected def mockSubscriptionSubmitFailure(ex: Exception): OngoingStubbing[Future[SubscriptionUpdateResponse]] =
+    when(mockSubscriptionsConnector.updateSubscription(any(), any())(any()))
+      .thenThrow(ex)
+
+  protected def mockSubscriptionUpdate(
+    pptReference: String,
+    request: SubscriptionUpdateRequest,
+    subscription: SubscriptionUpdateSuccessfulResponse
+  ): OngoingStubbing[Future[SubscriptionUpdateResponse]] =
+    when(
+      mockSubscriptionsConnector.updateSubscription(ArgumentMatchers.eq(pptReference), ArgumentMatchers.eq(request))(
+        any[HeaderCarrier]
+      )
+    ).thenReturn(Future.successful(subscription))
+
+  protected def mockNonRepudiationSubmission(
+    testEncodedPayload: String,
+    expectedMetadata: NonRepudiationMetadata,
+    response: NonRepudiationSubmissionAccepted
+  )(implicit hc: HeaderCarrier): OngoingStubbing[Future[NonRepudiationSubmissionAccepted]] =
+    when(
+      mockNonRepudiationConnector.submitNonRepudiation(ArgumentMatchers.eq(testEncodedPayload),
+                                                       ArgumentMatchers.eq(expectedMetadata)
+      )(ArgumentMatchers.eq(hc))
+    ).thenReturn(Future.successful(response))
+
+  protected def mockNonRepudiationSubmissionFailure(
+    ex: Exception
+  ): OngoingStubbing[Future[NonRepudiationSubmissionAccepted]] =
+    when(mockNonRepudiationConnector.submitNonRepudiation(any(), any())(any()))
+      .thenThrow(ex)
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/config/AppConfigSpec.scala
@@ -34,8 +34,12 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         |microservice.services.auth.port=9988
         |microservice.metrics.graphite.host=graphite
         |microservice.services.eis.bearerToken=test123456
+        |microservice.services.nrs.host=localhost
+        |microservice.services.nrs.port=8506
+        |microservice.services.nrs.api-key=test-key
         |auditing.enabled=true
         |eis.environment=ist0
+        |nrs.retries=["1s", "2s", "4s"]
     """.stripMargin)
 
   private val validServicesConfiguration = Configuration(validAppConfig)

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/NrsTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/NrsTestData.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models
+
+import org.joda.time
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve._
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.IdentityData
+import uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation.NonRepudiationService.NonRepudiationIdentityRetrievals
+
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
+
+trait NrsTestData {
+
+  val testAffinityGroup: AffinityGroup     = AffinityGroup.Organisation
+  val testProviderId: String               = "testProviderID"
+  val testProviderType: String             = "GovernmentGateway"
+  val testCredentials: Credentials         = Credentials(testProviderId, testProviderType)
+  val testInternalid                       = "INT-123-456-789"
+  val testExternalId                       = "testExternalId"
+  val testAgentCode                        = "testAgentCode"
+  val testConfidenceLevel: ConfidenceLevel = ConfidenceLevel.L200
+  val testSautr                            = "testSautr"
+  val testNino                             = "NB686868C"
+
+  val testDate: LocalDate         = LocalDate.of(2017, 1, 1)
+  val testDateTime: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)
+
+  val testAuthName: Name =
+    uk.gov.hmrc.auth.core.retrieve.Name(Some("testFirstName"), Some("testLastName"))
+
+  val testAuthDateOfBirth: org.joda.time.LocalDate = org.joda.time.LocalDate.now()
+  val testEmail: String                            = "testEmail"
+  val testPPTReference: String                     = "XMPPT123456789"
+  val testAuthToken: String                        = "testAuthToken"
+  val testUserHeaders: Map[String, String]         = Map("testKey" -> "testValue")
+  val testSearchKeys: Map[String, String]          = Map("pptReference" -> testPPTReference)
+
+  val testAgentInformation: AgentInformation =
+    AgentInformation(Some("testAgentId"), Some("testAgentCode"), Some("testAgentFriendlyName"))
+
+  val testGroupIdentifier                  = "testGroupIdentifier"
+  val testCredentialRole: User.type        = User
+  val testMdtpInformation: MdtpInformation = MdtpInformation("testDeviceId", "testSessionId")
+
+  val testItmpName: ItmpName =
+    ItmpName(Some("testGivenName"), Some("testMiddleName"), Some("testFamilyName"))
+
+  val testItmpDateOfBirth: time.LocalDate = org.joda.time.LocalDate.now()
+
+  val testItmpAddress: ItmpAddress =
+    ItmpAddress(Some("testLine1"), None, None, None, None, Some("testPostcode"), None, None)
+
+  val testCredentialStrength: String = CredentialStrength.strong
+
+  val testLoginTimes: LoginTimes =
+    LoginTimes(org.joda.time.DateTime.now(), Some(org.joda.time.DateTime.now()))
+
+  val testNonRepudiationIdentityData: IdentityData = IdentityData(Some(testInternalid),
+                                                                  Some(testExternalId),
+                                                                  Some(testAgentCode),
+                                                                  Some(testCredentials),
+                                                                  testConfidenceLevel,
+                                                                  Some(testNino),
+                                                                  Some(testSautr),
+                                                                  Some(testAuthName),
+                                                                  Some(testAuthDateOfBirth),
+                                                                  Some(testEmail),
+                                                                  testAgentInformation,
+                                                                  Some(testGroupIdentifier),
+                                                                  Some(testCredentialRole),
+                                                                  Some(testMdtpInformation),
+                                                                  Some(testItmpName),
+                                                                  Some(testItmpDateOfBirth),
+                                                                  Some(testItmpAddress),
+                                                                  Some(testAffinityGroup),
+                                                                  Some(testCredentialStrength),
+                                                                  testLoginTimes
+  )
+
+  val identityJson: JsValue = Json.toJson(testNonRepudiationIdentityData)
+
+  implicit class RetrievalCombiner[A](a: A) {
+    def ~[B](b: B): A ~ B = new ~(a, b)
+  }
+
+  val testAuthRetrievals: NonRepudiationIdentityRetrievals =
+    Some(testAffinityGroup) ~
+      Some(testInternalid) ~
+      Some(testExternalId) ~
+      Some(testAgentCode) ~
+      Some(testCredentials) ~
+      testConfidenceLevel ~
+      Some(testNino) ~
+      Some(testSautr) ~
+      Some(testAuthName) ~
+      Some(testAuthDateOfBirth) ~
+      Some(testEmail) ~
+      testAgentInformation ~
+      Some(testGroupIdentifier) ~
+      Some(testCredentialRole) ~
+      Some(testMdtpInformation) ~
+      Some(testItmpName) ~
+      Some(testItmpDateOfBirth) ~
+      Some(testItmpAddress) ~
+      Some(testCredentialStrength) ~
+      testLoginTimes
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/SubscriptionTestData.scala
@@ -30,6 +30,8 @@ import java.time.format.DateTimeFormatter
 
 trait SubscriptionTestData {
 
+  protected val pptUserHeaders: Map[String, String] = Map("testHeaderKey" -> "testHeaderValue")
+
   protected val ukLimitedCompanySubscription: Subscription = Subscription(
     legalEntityDetails =
       LegalEntityDetails(dateOfApplication =
@@ -114,27 +116,27 @@ trait SubscriptionTestData {
                                   subscription.groupSubscription
     )
 
-  protected def createSubscriptionUpdateResponse(
-    subscription: Subscription,
-    changeOfCircumstanceDetails: ChangeOfCircumstanceDetails
-  ) =
-    SubscriptionUpdateRequest(changeOfCircumstanceDetails = changeOfCircumstanceDetails,
-                              legalEntityDetails =
-                                subscription.legalEntityDetails,
-                              principalPlaceOfBusinessDetails =
-                                subscription.principalPlaceOfBusinessDetails,
-                              primaryContactDetails =
-                                subscription.primaryContactDetails,
-                              businessCorrespondenceDetails =
-                                subscription.businessCorrespondenceDetails,
-                              taxObligationStartDate =
-                                subscription.taxObligationStartDate,
-                              last12MonthTotalTonnageAmt =
-                                subscription.last12MonthTotalTonnageAmt.map(_.toLong),
-                              declaration =
-                                subscription.declaration,
-                              groupSubscription =
-                                subscription.groupSubscription
+  protected def createSubscriptionUpdateRequest(subscription: Subscription): SubscriptionUpdateRequest =
+    SubscriptionUpdateRequest(
+      changeOfCircumstanceDetails =
+        subscription.changeOfCircumstanceDetails.getOrElse(ChangeOfCircumstanceDetails("02")),
+      legalEntityDetails =
+        subscription.legalEntityDetails,
+      principalPlaceOfBusinessDetails =
+        subscription.principalPlaceOfBusinessDetails,
+      primaryContactDetails =
+        subscription.primaryContactDetails,
+      businessCorrespondenceDetails =
+        subscription.businessCorrespondenceDetails,
+      taxObligationStartDate =
+        subscription.taxObligationStartDate,
+      last12MonthTotalTonnageAmt =
+        subscription.last12MonthTotalTonnageAmt.map(_.toLong),
+      declaration =
+        subscription.declaration,
+      groupSubscription =
+        subscription.groupSubscription,
+      userHeaders = Some(pptUserHeaders)
     )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/service/nonRepudiation/NonRepudiationServiceSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/service/nonRepudiation/NonRepudiationServiceSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.service.nonRepudiation
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier}
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.AuthTestSupport
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.unit.MockConnectors
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models.{NrsTestData, SubscriptionTestData}
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.{
+  NonRepudiationMetadata,
+  NonRepudiationSubmissionAccepted
+}
+import uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation.NonRepudiationService
+import uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation.NonRepudiationService.nonRepudiationIdentityRetrievals
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+import scala.concurrent.ExecutionContext
+
+class NonRepudiationServiceSpec
+    extends AnyWordSpec with GuiceOneAppPerSuite with AuthTestSupport with NrsTestData with BeforeAndAfterEach
+    with ScalaFutures with Matchers with MockConnectors with SubscriptionTestData {
+
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  implicit val hc: HeaderCarrier =
+    HeaderCarrier(authorization = Some(Authorization(testAuthToken)))
+
+  val nonRepudiationService: NonRepudiationService =
+    NonRepudiationService(mockNonRepudiationConnector, mockAuthConnector)
+
+  implicit val request: Request[AnyContent] = FakeRequest()
+
+  "submitNonRepudiation" should {
+    val testPayloadString = "testPayloadString"
+
+    "call the nonRepudiationConnector with the correctly formatted metadata" in {
+      val testSubmissionId = "testSubmissionId"
+
+      val testPayloadChecksum = MessageDigest.getInstance("SHA-256")
+        .digest(testPayloadString.getBytes(StandardCharsets.UTF_8))
+        .map("%02x".format(_)).mkString
+
+      val testEncodedPayload =
+        Base64.getEncoder.encodeToString(testPayloadString.getBytes(StandardCharsets.UTF_8))
+
+      val expectedMetadata = NonRepudiationMetadata(businessId = "ppt",
+                                                    notableEvent = "ppt-subscription",
+                                                    payloadContentType = "application/json",
+                                                    payloadSha256Checksum = testPayloadChecksum,
+                                                    userSubmissionTimestamp = testDateTime,
+                                                    identityData = testNonRepudiationIdentityData,
+                                                    userAuthToken = testAuthToken,
+                                                    headerData = testUserHeaders,
+                                                    searchKeys =
+                                                      Map("pptReference" -> testPPTReference)
+      )
+      mockAuthorization(nonRepudiationIdentityRetrievals, testAuthRetrievals)
+      mockNonRepudiationSubmission(testEncodedPayload,
+                                   expectedMetadata,
+                                   NonRepudiationSubmissionAccepted(testSubmissionId)
+      )
+
+      val res =
+        nonRepudiationService.submitNonRepudiation(testPayloadString, testDateTime, testPPTReference, testUserHeaders)
+
+      await(res) mustBe NonRepudiationSubmissionAccepted(testSubmissionId)
+    }
+
+    "throw an exception when the NRS call fails" in {
+      val testExceptionMessage = "testExceptionMessage"
+
+      mockAuthorization(nonRepudiationIdentityRetrievals, testAuthRetrievals)
+      mockNonRepudiationSubmissionFailure(new RuntimeException(testExceptionMessage))
+
+      val res =
+        nonRepudiationService.submitNonRepudiation(testPayloadString, testDateTime, testPPTReference, testUserHeaders)
+
+      intercept[RuntimeException](await(res))
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/util/RetryISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/util/RetryISpec.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.util
+
+import akka.actor.ActorSystem
+import com.codahale.metrics.SharedMetricRegistries
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.test.DefaultAwaitTimeout
+import play.api.test.Helpers.await
+import uk.gov.hmrc.plasticpackagingtaxreturns.util.RetryISpec.{
+  neverRetry,
+  noParticularReason,
+  retryFailures,
+  someRetries
+}
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Success, Try}
+
+class RetryISpec extends AnyWordSpec with Matchers with DefaultAwaitTimeout with BeforeAndAfterEach {
+
+  private implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  private val retryable = new Retry() {
+    override def actorSystem: ActorSystem = ActorSystem()
+  }
+
+  override protected def beforeEach(): Unit =
+    SharedMetricRegistries.clear()
+
+  "A retryable" should {
+
+    "not retry" when {
+      "configured as such" in {
+        val consistentlyFailingOperation = ConsistentlyFailingOperation()
+
+        intercept[IllegalStateException] {
+          await(retryable.retry()(retryFailures, noParticularReason)(consistentlyFailingOperation.doIt()))
+        }
+
+        consistentlyFailingOperation.invocationCount mustBe 1
+      }
+    }
+
+    "retry a number of times" when {
+      "failure occurs" in {
+
+        val consistentlyFailingOperation = ConsistentlyFailingOperation()
+
+        intercept[IllegalStateException] {
+          await(
+            retryable.retry(someRetries: _*)(retryFailures, noParticularReason)(consistentlyFailingOperation.doIt())
+          )
+        }
+
+        consistentlyFailingOperation.invocationCount mustBe (someRetries.length + 1)
+      }
+    }
+
+    "retry until successful" when {
+      "failure occurs initially" in {
+
+        val temporarilyFailingOperation = TemporarilyFailingOperation(1, "All Good")
+
+        await(retryable.retry(someRetries: _*)(retryFailures, noParticularReason)(temporarilyFailingOperation.doIt()))
+
+        temporarilyFailingOperation.invocationCount mustBe (temporarilyFailingOperation.numFailures + 1)
+      }
+    }
+
+    "fail immediately" when {
+      "no retry is required" in {
+        val consistentlyFailingOperation = ConsistentlyFailingOperation()
+
+        intercept[IllegalStateException] {
+          await(retryable.retry(someRetries: _*)(neverRetry, noParticularReason)(consistentlyFailingOperation.doIt()))
+        }
+
+        consistentlyFailingOperation.invocationCount mustBe 1
+      }
+    }
+
+    "delay before retrying" in {
+      val consistentlyFailingOperation = ConsistentlyFailingOperation()
+
+      val retryDelayMs         = 1000
+      val timeBeforeInvocation = System.currentTimeMillis()
+
+      intercept[IllegalStateException] {
+        await(
+          retryable.retry(FiniteDuration(retryDelayMs, TimeUnit.MILLISECONDS))(retryFailures, noParticularReason)(
+            consistentlyFailingOperation.doIt()
+          )
+        )
+      }
+
+      consistentlyFailingOperation.lastInvocationTime should be > (timeBeforeInvocation + retryDelayMs)
+    }
+  }
+}
+
+class TemporarilyFailingOperation[A](val numFailures: Int, val successVal: A) {
+  var invocationCount          = 0
+  var lastInvocationTime: Long = -1
+
+  def doIt(): Future[A] = {
+    invocationCount += 1
+    lastInvocationTime = System.currentTimeMillis()
+    if (numFailures == -1 || invocationCount <= numFailures)
+      Future.failed(new IllegalStateException("BANG!"))
+    else
+      Future.successful(successVal)
+  }
+
+}
+
+object RetryISpec {
+
+  def retryFailures[A](value: Try[A]): Boolean =
+    value match {
+      case Success(_) => false
+      case _          => true
+    }
+
+  //noinspection ScalaUnusedSymbol
+  def neverRetry[A](value: Try[A]): Boolean = false
+
+  //noinspection ScalaUnusedSymbol
+  def noParticularReason[A](value: Try[A]): String = "no particular reason"
+
+  def someRetries =
+    List(FiniteDuration(1, TimeUnit.MILLISECONDS),
+         FiniteDuration(2, TimeUnit.MILLISECONDS),
+         FiniteDuration(3, TimeUnit.MILLISECONDS)
+    )
+
+}
+
+object TemporarilyFailingOperation {
+
+  def apply[A](numFailures: Int, successVal: A): TemporarilyFailingOperation[A] =
+    new TemporarilyFailingOperation(numFailures, successVal)
+
+}
+
+class ConsistentlyFailingOperation extends TemporarilyFailingOperation(-1, "All good")
+
+object ConsistentlyFailingOperation {
+  def apply[A](): ConsistentlyFailingOperation = new ConsistentlyFailingOperation()
+}


### PR DESCRIPTION
### Description of Work carried through

- Added NrsConnector to submit the updated subscription.
- Sending the NrsDetails as part of the audit event
- Also added the processing date time to audit event

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
