### PR TITLE
PPTP-1117 : Make "change of circumstances" optional in "view subscrip…

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/SubscriptionDisplayResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionDisplay/SubscriptionDisplayResponse.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
 
 case class SubscriptionDisplayResponse(
   processingDate: String,
-  changeOfCircumstanceDetails: ChangeOfCircumstanceDetails,
+  changeOfCircumstanceDetails: Option[ChangeOfCircumstanceDetails],
   legalEntityDetails: LegalEntityDetails,
   principalPlaceOfBusinessDetails: PrincipalPlaceOfBusinessDetails,
   primaryContactDetails: PrimaryContactDetails,

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/SubscriptionTestData.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/models/SubscriptionTestData.scala
@@ -95,8 +95,10 @@ trait SubscriptionTestData {
   protected def createSubscriptionDisplayResponse(subscription: Subscription) =
     SubscriptionDisplayResponse(processingDate = "2020-05-05",
                                 changeOfCircumstanceDetails =
-                                  ChangeOfCircumstanceDetails(changeOfCircumstance =
-                                    "update"
+                                  Some(
+                                    ChangeOfCircumstanceDetails(changeOfCircumstance =
+                                      "update"
+                                    )
                                   ),
                                 legalEntityDetails =
                                   subscription.legalEntityDetails,


### PR DESCRIPTION
…tion response"

This will not be set when a subscription is first created.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work) : https://github.com/hmrc/plastic-packaging-tax-returns-frontend/pull/67
 - [x] User Acceptance Tests (UAT) were run locally and have passed - PPT return test failed; don't know why and don't have the time to investigate at the moment.
