### PR TITLE
PPTP-1210 - Update application library dependencies

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,9 +25,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided
@@ -35,7 +35,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.backend.filters.BackendFilters"
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,12 +5,12 @@ import sbt._
 
 object AppDependencies {
 
-  val compile = Seq("uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.2.0",
+  val compile = Seq("uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.14.0",
                     "uk.gov.hmrc"       %% "simple-reactivemongo" % "8.0.0-play-28",
                     "com.typesafe.play" %% "play-json-joda"       % "2.6.14"
   )
 
-  val test = Seq("uk.gov.hmrc" %% "bootstrap-test-play-28" % "5.2.0" % Test,
+  val test = Seq("uk.gov.hmrc" %% "bootstrap-test-play-28" % "5.14.0" % Test,
                  "org.scalatest"          %% "scalatest"             % "3.2.5"    % Test,
                  "com.typesafe.play"      %% "play-test"             % current    % Test,
                  "org.mockito"             % "mockito-core"          % "3.9.0"    % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += Resolver.typesafeRepo("releases")
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/auditor/AuditorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/auditor/AuditorSpec.scala
@@ -107,12 +107,7 @@ class AuditorSpec extends ConnectorISpec with Injector with ScalaFutures with Su
                                           |                    "clientPort": "-"
                                           |                  },
                                           |                  "detail": $body,
-                                          |                  "generatedAt": "$${json-unit.any-string}",
-                                          |                  "metadata": {
-                                          |                    "sendAttemptAt": "$${json-unit.any-string}",
-                                          |                    "instanceID": "$${json-unit.any-string}",
-                                          |                    "sequence": "$${json-unit.any-number}"
-                                          |                  }
+                                          |                  "generatedAt": "$${json-unit.any-string}"
                                           |                }""".stripMargin, true, true))
       )
       true


### PR DESCRIPTION
Update application library dependencies

Fixed config warnings
```
2021-09-23 08:36:35,234 level=[WARN] logger=[uk.gov.hmrc.play.bootstrap.config.DeprecatedConfigChecker] thread=[play-dev-mode-akka.actor.default-dispatcher-8] rid=[] user=[] message=[The key 'play.modules.enabled' is configured with value 'uk.gov.hmrc.play.bootstrap.AuditModule', which is deprecated. Please use 'uk.gov.hmrc.play.audit.AuditModule' instead.] 


2021-09-23 08:36:37,149 level=[WARN] logger=[uk.gov.hmrc.play.bootstrap.backend.filters.BackendFilters] thread=[play-dev-mode-akka.actor.default-dispatcher-8] rid=[] user=[] message=[play.http.filters = "uk.gov.hmrc.play.bootstrap.backend.filters.BackendFilters" is no longer required and can be removed. Filters are configured using play's default filter system: https://www.playframework.com/documentation/2.7.x/Filters#Default-Filters] 
```

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
