### PR TITLE
PPTP-1244 success response contains pptReferenceNumber, not pptReference

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateSuccessfulResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/subscriptionUpdate/SubscriptionUpdateSuccessfulResponse.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 import java.time.ZonedDateTime
 
 case class SubscriptionUpdateSuccessfulResponse(
-  pptReference: String,
+  pptReferenceNumber: String,
   processingDate: ZonedDateTime,
   formBundleNumber: String
 ) extends SubscriptionUpdateResponse

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/SubscriptionController.scala
@@ -76,7 +76,7 @@ class SubscriptionController @Inject() (
                                           pptSubscription = pptSubscription,
                                           nrsFailureResponse = None
           ),
-          pptReference = Some(eisResponse.pptReference),
+          pptReference = Some(eisResponse.pptReferenceNumber),
           processingDateTime = Some(eisResponse.processingDate)
         )
         handleNrsSuccess(eisResponse, nrSubmissionId)
@@ -87,7 +87,7 @@ class SubscriptionController @Inject() (
                                           pptSubscription = pptSubscription,
                                           nrsFailureResponse = Some(exception.getMessage)
           ),
-          pptReference = Some(eisResponse.pptReference)
+          pptReference = Some(eisResponse.pptReferenceNumber)
         )
         handleNrsFailure(eisResponse, exception)
     }
@@ -99,7 +99,7 @@ class SubscriptionController @Inject() (
   )(implicit hc: HeaderCarrier): Future[NonRepudiationSubmissionAccepted] =
     nonRepudiationService.submitNonRepudiation(toJson(pptSubscription).toString,
                                                eisResponse.processingDate,
-                                               eisResponse.pptReference,
+                                               eisResponse.pptReferenceNumber,
                                                request.body.userHeaders.getOrElse(Map.empty)
     )
 
@@ -109,7 +109,7 @@ class SubscriptionController @Inject() (
   ): Future[Result] =
     Future.successful(
       Ok(
-        SubscriptionUpdateWithNrsFailureResponse(eisResponse.pptReference,
+        SubscriptionUpdateWithNrsFailureResponse(eisResponse.pptReferenceNumber,
                                                  eisResponse.processingDate,
                                                  eisResponse.formBundleNumber,
                                                  exception.getMessage
@@ -119,7 +119,7 @@ class SubscriptionController @Inject() (
 
   private def handleNrsSuccess(eisResponse: SubscriptionUpdateSuccessfulResponse, nrSubmissionId: String): Result =
     Ok(
-      SubscriptionUpdateWithNrsSuccessfulResponse(eisResponse.pptReference,
+      SubscriptionUpdateWithNrsSuccessfulResponse(eisResponse.pptReferenceNumber,
                                                   eisResponse.processingDate,
                                                   eisResponse.formBundleNumber,
                                                   nrSubmissionId

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/SubscriptionsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/SubscriptionsConnectorSpec.scala
@@ -94,7 +94,7 @@ class SubscriptionsConnectorSpec extends ConnectorISpec with Injector with Subsc
             SubscriptionUpdateSuccessfulResponse
           ]
 
-        res.pptReference mustBe pptReference
+        res.pptReferenceNumber mustBe pptReference
         res.formBundleNumber mustBe formBundleNumber
         res.processingDate mustBe ZonedDateTime.parse(subscriptionProcessingDate)
         getTimer(updateSubscriptionTimer).getCount mustBe 1
@@ -116,7 +116,7 @@ class SubscriptionsConnectorSpec extends ConnectorISpec with Injector with Subsc
             SubscriptionUpdateSuccessfulResponse
           ]
 
-        res.pptReference mustBe pptReference
+        res.pptReferenceNumber mustBe pptReference
         res.formBundleNumber mustBe formBundleNumber
         res.processingDate mustBe ZonedDateTime.parse(subscriptionProcessingDate)
         getTimer(updateSubscriptionTimer).getCount mustBe 1
@@ -216,9 +216,9 @@ class SubscriptionsConnectorSpec extends ConnectorISpec with Injector with Subsc
           aResponse()
             .withStatus(Status.OK)
             .withBody(
-              Json.obj("pptReference"     -> pptReference,
-                       "processingDate"   -> subscriptionProcessingDate,
-                       "formBundleNumber" -> formBundleNumber
+              Json.obj("pptReferenceNumber" -> pptReference,
+                       "processingDate"     -> subscriptionProcessingDate,
+                       "formBundleNumber"   -> formBundleNumber
               ).toString
             )
         )

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/controllers/SubscriptionControllerSpec.scala
@@ -73,7 +73,7 @@ class SubscriptionControllerSpec
   }
 
   val subscriptionUpdateResponse: SubscriptionUpdateSuccessfulResponse = SubscriptionUpdateSuccessfulResponse(
-    pptReference = pptReference,
+    pptReferenceNumber = pptReference,
     processingDate = ZonedDateTime.now(ZoneOffset.UTC),
     formBundleNumber = "12345678901"
   )
@@ -149,14 +149,14 @@ class SubscriptionControllerSpec
 
           status(result) must be(OK)
           val response = contentAsJson(result).as[SubscriptionUpdateWithNrsSuccessfulResponse]
-          response.pptReference mustBe subscriptionUpdateResponse.pptReference
+          response.pptReference mustBe subscriptionUpdateResponse.pptReferenceNumber
           response.formBundleNumber mustBe subscriptionUpdateResponse.formBundleNumber
           response.processingDate mustBe subscriptionUpdateResponse.processingDate
           response.nrSubmissionId mustBe nrSubmissionId
           verify(mockNonRepudiationService).submitNonRepudiation(
             ArgumentMatchers.eq(Json.toJson(request.toSubscription).toString),
             any[ZonedDateTime],
-            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReference),
+            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReferenceNumber),
             ArgumentMatchers.eq(pptUserHeaders)
           )(any[HeaderCarrier])
         }
@@ -175,7 +175,7 @@ class SubscriptionControllerSpec
 
           status(result) must be(OK)
           val response = contentAsJson(result).as[SubscriptionUpdateWithNrsFailureResponse]
-          response.pptReference mustBe subscriptionUpdateResponse.pptReference
+          response.pptReference mustBe subscriptionUpdateResponse.pptReferenceNumber
           response.formBundleNumber mustBe subscriptionUpdateResponse.formBundleNumber
           response.processingDate mustBe subscriptionUpdateResponse.processingDate
           response.nrsFailureReason mustBe nrsErrorMessage
@@ -183,7 +183,7 @@ class SubscriptionControllerSpec
           verify(mockNonRepudiationService).submitNonRepudiation(
             ArgumentMatchers.contains(Json.toJson(request.toSubscription).toString),
             any[ZonedDateTime],
-            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReference),
+            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReferenceNumber),
             ArgumentMatchers.eq(pptUserHeaders)
           )(any[HeaderCarrier])
         }
@@ -208,14 +208,14 @@ class SubscriptionControllerSpec
 
           status(result) must be(OK)
           val response = contentAsJson(result).as[SubscriptionUpdateWithNrsSuccessfulResponse]
-          response.pptReference mustBe subscriptionUpdateResponse.pptReference
+          response.pptReference mustBe subscriptionUpdateResponse.pptReferenceNumber
           response.formBundleNumber mustBe subscriptionUpdateResponse.formBundleNumber
           response.processingDate mustBe subscriptionUpdateResponse.processingDate
           response.nrSubmissionId mustBe nrSubmissionId
           verify(mockNonRepudiationService).submitNonRepudiation(
             ArgumentMatchers.eq(Json.toJson(request.toSubscription).toString()),
             any[ZonedDateTime],
-            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReference),
+            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReferenceNumber),
             ArgumentMatchers.eq(pptUserHeaders)
           )(any[HeaderCarrier])
         }
@@ -234,7 +234,7 @@ class SubscriptionControllerSpec
 
           status(result) must be(OK)
           val response = contentAsJson(result).as[SubscriptionUpdateWithNrsFailureResponse]
-          response.pptReference mustBe subscriptionUpdateResponse.pptReference
+          response.pptReference mustBe subscriptionUpdateResponse.pptReferenceNumber
           response.formBundleNumber mustBe subscriptionUpdateResponse.formBundleNumber
           response.processingDate mustBe subscriptionUpdateResponse.processingDate
           response.nrsFailureReason mustBe nrsErrorMessage
@@ -242,7 +242,7 @@ class SubscriptionControllerSpec
           verify(mockNonRepudiationService).submitNonRepudiation(
             ArgumentMatchers.contains(Json.toJson(request.toSubscription).toString),
             any[ZonedDateTime],
-            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReference),
+            ArgumentMatchers.eq(subscriptionUpdateResponse.pptReferenceNumber),
             ArgumentMatchers.eq(pptUserHeaders)
           )(any[HeaderCarrier])
         }


### PR DESCRIPTION
### Description of Work

Success reponse for create/update schema contains field called pptReferenceNumber, not pptReference.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
