### PR TITLE
BAU : Ensure TaxReturn changes are backwards-compat

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturn.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturn.scala
@@ -29,7 +29,7 @@ object TaxReturnObligation {
 
 case class TaxReturn(
   id: String,
-  obligation: TaxReturnObligation,
+  obligation: Option[TaxReturnObligation] = None,
   manufacturedPlasticWeight: Option[ManufacturedPlasticWeight] = None,
   importedPlasticWeight: Option[ImportedPlasticWeight] = None,
   humanMedicinesPlasticWeight: Option[HumanMedicinesPlasticWeight] = None,

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturnRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/models/TaxReturnRequest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtaxreturns.models
 
 case class TaxReturnRequest(
-  obligation: TaxReturnObligation,
+  obligation: Option[TaxReturnObligation] = None,
   manufacturedPlasticWeight: Option[ManufacturedPlasticWeight],
   importedPlasticWeight: Option[ImportedPlasticWeight],
   humanMedicinesPlasticWeight: Option[HumanMedicinesPlasticWeight],

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnBuilder.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnBuilder.scala
@@ -40,7 +40,7 @@ trait TaxReturnBuilder {
     modifiers.foldLeft(modelWithDefaults)((current, modifier) => modifier(current))
 
   private def modelWithDefaults: TaxReturn =
-    TaxReturn(id = "id", obligation = defaultObligation)
+    TaxReturn(id = "id", obligation = Some(defaultObligation))
 
   val defaultObligation = TaxReturnObligation(fromDate = LocalDate.parse("2022-04-01"),
                                               toDate = LocalDate.parse("2022-06-30"),

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnRequestBuilder.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/builders/TaxReturnRequestBuilder.scala
@@ -35,7 +35,7 @@ trait TaxReturnRequestBuilder {
     modifiers.foldLeft(modelWithDefaults)((current, modifier) => modifier(current))
 
   private def modelWithDefaults: TaxReturnRequest =
-    TaxReturnRequest(obligation = defaultTaxReturnRequestObligation,
+    TaxReturnRequest(obligation = Some(defaultTaxReturnRequestObligation),
                      manufacturedPlasticWeight = Some(ManufacturedPlasticWeight(5)),
                      importedPlasticWeight = Some(ImportedPlasticWeight(6)),
                      humanMedicinesPlasticWeight = Some(HumanMedicinesPlasticWeight(1)),


### PR DESCRIPTION
This is necessary since successful registration results in the creation of a TaxReturn. Thus, we need to remain compatible with these existing TaxReturns which exist in the production Returns Mongo.

