### PR TITLE
PPTP-1777 : Returns Calculations

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/config/AppConfig.scala
@@ -68,4 +68,6 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val nrsRetries: Seq[FiniteDuration] = config.get[Seq[FiniteDuration]]("nrs.retries")
 
   val desBearerToken: String = s"Bearer ${config.get[String]("microservice.services.des.bearerToken")}"
+
+  val taxRatePoundsPerKg: BigDecimal = BigDecimal(config.get[String]("taxRatePoundsPerKg"))
 }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/returns/ReturnsSubmissionRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/returns/ReturnsSubmissionRequest.scala
@@ -36,33 +36,29 @@ case class EisReturnDetails(
 object EisReturnDetails {
   implicit val format: OFormat[EisReturnDetails] = Json.format[EisReturnDetails]
 
-  def fromTaxReturn(taxReturn: TaxReturn) =
-    returns.EisReturnDetails(
-      manufacturedWeight = taxReturn.manufacturedPlasticWeight match {
-        case Some(weight) => weight.totalKg
-        case _            => 0
-      },
-      importedWeight = taxReturn.importedPlasticWeight match {
-        case Some(weight) => weight.totalKg
-        case _            => 0
-      },
-      totalNotLiable = 0,
-      humanMedicines = taxReturn.humanMedicinesPlasticWeight match {
-        case Some(weight) => weight.totalKg
-        case _            => 0
-      },
-      directExports = taxReturn.exportedPlasticWeight match {
-        case Some(weight) => weight.totalKg
-        case _            => 0
-      },
-      recycledPlastic = taxReturn.recycledPlasticWeight match {
-        case Some(weight) => weight.totalKg
-        case _            => 0
-      },
-      creditForPeriod = 0,
-      totalWeight = 0,
-      taxDue = 0
+  def apply(taxReturn: TaxReturn, taxRatePoundsPerKg: BigDecimal): EisReturnDetails = {
+    val manufacturedWeightKg = taxReturn.manufacturedPlasticWeight.map(_.totalKg).getOrElse(0L)
+    val importedWeightKg     = taxReturn.importedPlasticWeight.map(_.totalKg).getOrElse(0L)
+    val liableKg             = manufacturedWeightKg + importedWeightKg
+
+    val humanMedicinesWeightKg = taxReturn.humanMedicinesPlasticWeight.map(_.totalKg).getOrElse(0L)
+    val directExportsWeightKg  = taxReturn.exportedPlasticWeight.map(_.totalKg).getOrElse(0L)
+    val recycledWeightKg       = taxReturn.recycledPlasticWeight.map(_.totalKg).getOrElse(0L)
+    val notLiableKg            = humanMedicinesWeightKg + directExportsWeightKg + recycledWeightKg
+
+    val taxableKg = Math.max(liableKg - notLiableKg, 0)
+
+    returns.EisReturnDetails(manufacturedWeight = manufacturedWeightKg,
+                             importedWeight = importedWeightKg,
+                             totalNotLiable = notLiableKg,
+                             humanMedicines = humanMedicinesWeightKg,
+                             directExports = directExportsWeightKg,
+                             recycledPlastic = recycledWeightKg,
+                             creditForPeriod = 0,
+                             totalWeight = taxableKg,
+                             taxDue = BigDecimal(taxableKg) * taxRatePoundsPerKg
     )
+  }
 
 }
 
@@ -76,12 +72,12 @@ case class ReturnsSubmissionRequest(
 object ReturnsSubmissionRequest {
   implicit val format: OFormat[ReturnsSubmissionRequest] = Json.format[ReturnsSubmissionRequest]
 
-  def fromTaxReturn(taxReturn: TaxReturn) =
+  def apply(taxReturn: TaxReturn, taxRatePoundsPerKg: BigDecimal): ReturnsSubmissionRequest =
     ReturnsSubmissionRequest(returnType = taxReturn.returnType.getOrElse(ReturnType.NEW),
                              periodKey = taxReturn.obligation.map(_.periodKey).getOrElse(
                                throw new IllegalStateException("Obligation is absent")
                              ),
-                             returnDetails = EisReturnDetails.fromTaxReturn(taxReturn)
+                             returnDetails = EisReturnDetails(taxReturn, taxRatePoundsPerKg: BigDecimal)
     )
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -159,3 +159,5 @@ eis.environment = "ist0"
 
 # Defines the number and individual backoff delays for NRS submission retries
 nrs.retries = ["1s", "2s", "4s"]
+
+taxRatePoundsPerKg = "0.20"

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/returns/ReturnsSubmissionRequestSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/returns/ReturnsSubmissionRequestSpec.scala
@@ -24,30 +24,58 @@ import uk.gov.hmrc.plasticpackagingtaxreturns.models.ReturnType
 class ReturnsSubmissionRequestSpec extends AnyWordSpec with TaxReturnBuilder {
 
   "The EIS Returns Submission Request Object" should {
-    "convert a stored Tax Return as expected" in {
-      val taxReturn = aTaxReturn(withManufacturedPlasticWeight(1000),
-                                 withImportedPlasticWeight(2000),
-                                 withHumanMedicinesPlasticWeight(3000),
-                                 withDirectExportDetails(4000),
-                                 withRecycledPlasticWeight(5000)
-      )
+    "convert a stored Tax Return" when {
+      "positive liability" in {
+        val taxReturn = aTaxReturn(withManufacturedPlasticWeight(9000),
+                                   withImportedPlasticWeight(8000),
+                                   withHumanMedicinesPlasticWeight(5000),
+                                   withDirectExportDetails(4000),
+                                   withRecycledPlasticWeight(3000)
+        )
 
-      val eisReturnsSubmissionRequest = ReturnsSubmissionRequest.fromTaxReturn(taxReturn)
+        val eisReturnsSubmissionRequest = ReturnsSubmissionRequest(taxReturn, 0.20)
 
-      eisReturnsSubmissionRequest.returnDetails.manufacturedWeight mustBe 1000
-      eisReturnsSubmissionRequest.returnDetails.importedWeight mustBe 2000
-      eisReturnsSubmissionRequest.returnDetails.humanMedicines mustBe 3000
-      eisReturnsSubmissionRequest.returnDetails.directExports mustBe 4000
-      eisReturnsSubmissionRequest.returnDetails.recycledPlastic mustBe 5000
+        eisReturnsSubmissionRequest.returnDetails.manufacturedWeight mustBe 9000
+        eisReturnsSubmissionRequest.returnDetails.importedWeight mustBe 8000
+        eisReturnsSubmissionRequest.returnDetails.humanMedicines mustBe 5000
+        eisReturnsSubmissionRequest.returnDetails.directExports mustBe 4000
+        eisReturnsSubmissionRequest.returnDetails.recycledPlastic mustBe 3000
 
-      // TODO: fix up the translation of these values
-      eisReturnsSubmissionRequest.returnType mustBe ReturnType.NEW
-      eisReturnsSubmissionRequest.periodKey mustBe defaultObligation.periodKey
-      eisReturnsSubmissionRequest.submissionId mustBe None
-      eisReturnsSubmissionRequest.returnDetails.totalNotLiable mustBe 0
-      eisReturnsSubmissionRequest.returnDetails.totalWeight mustBe 0
-      eisReturnsSubmissionRequest.returnDetails.creditForPeriod mustBe 0
-      eisReturnsSubmissionRequest.returnDetails.taxDue mustBe 0
+        eisReturnsSubmissionRequest.returnType mustBe ReturnType.NEW
+        eisReturnsSubmissionRequest.periodKey mustBe defaultObligation.periodKey
+        eisReturnsSubmissionRequest.submissionId mustBe None
+
+        eisReturnsSubmissionRequest.returnDetails.totalNotLiable mustBe 5000 + 4000 + 3000
+        eisReturnsSubmissionRequest.returnDetails.totalWeight mustBe (9000 + 8000) - (5000 + 4000 + 3000)
+        eisReturnsSubmissionRequest.returnDetails.creditForPeriod mustBe 0
+        eisReturnsSubmissionRequest.returnDetails.taxDue mustBe ((9000 + 8000) - (5000 + 4000 + 3000)) * 0.20
+      }
+
+      "negative liability" in {
+        val taxReturn = aTaxReturn(withManufacturedPlasticWeight(1000),
+                                   withImportedPlasticWeight(2000),
+                                   withHumanMedicinesPlasticWeight(5000),
+                                   withDirectExportDetails(4000),
+                                   withRecycledPlasticWeight(3000)
+        )
+
+        val eisReturnsSubmissionRequest = ReturnsSubmissionRequest(taxReturn, 0.20)
+
+        eisReturnsSubmissionRequest.returnDetails.manufacturedWeight mustBe 1000
+        eisReturnsSubmissionRequest.returnDetails.importedWeight mustBe 2000
+        eisReturnsSubmissionRequest.returnDetails.humanMedicines mustBe 5000
+        eisReturnsSubmissionRequest.returnDetails.directExports mustBe 4000
+        eisReturnsSubmissionRequest.returnDetails.recycledPlastic mustBe 3000
+
+        eisReturnsSubmissionRequest.returnType mustBe ReturnType.NEW
+        eisReturnsSubmissionRequest.periodKey mustBe defaultObligation.periodKey
+        eisReturnsSubmissionRequest.submissionId mustBe None
+
+        eisReturnsSubmissionRequest.returnDetails.totalNotLiable mustBe 5000 + 4000 + 3000
+        eisReturnsSubmissionRequest.returnDetails.totalWeight mustBe 0
+        eisReturnsSubmissionRequest.returnDetails.creditForPeriod mustBe 0
+        eisReturnsSubmissionRequest.returnDetails.taxDue mustBe 0
+      }
     }
 
     "throw exception when obligation is not present" in {
@@ -59,7 +87,7 @@ class ReturnsSubmissionRequestSpec extends AnyWordSpec with TaxReturnBuilder {
       ).copy(obligation = None)
 
       intercept[IllegalStateException] {
-        ReturnsSubmissionRequest.fromTaxReturn(taxReturn)
+        ReturnsSubmissionRequest(taxReturn, 0.20)
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/config/AppConfigSpec.scala
@@ -41,6 +41,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         |auditing.enabled=true
         |eis.environment=ist0
         |nrs.retries=["1s", "2s", "4s"]
+        |taxRatePoundsPerKg=0.20
     """.stripMargin)
 
   private val validServicesConfiguration = Configuration(validAppConfig)
@@ -57,6 +58,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
       configService.auditingEnabled mustBe true
       configService.graphiteHost mustBe "graphite"
       configService.dbTimeToLiveInSeconds mustBe 100
+
+      configService.taxRatePoundsPerKg mustBe BigDecimal("0.20")
     }
   }
 }


### PR DESCRIPTION
Calculate derived fields in the returns creation message. Tax rate is defined in app config.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [ ] User Acceptance Tests (UAT) were run locally and have passed - N/A
