### PR TITLE
PPTP-1837 - Auth calls include the parameters for agent's delegated enrolment check

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorImpl.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorImpl.scala
@@ -57,7 +57,7 @@ class AuthenticatorImpl @Inject() (override val authConnector: AuthConnector, cc
     body: AuthorizedRequest[A] => Future[Result]
   ): Action[A] =
     Action.async(bodyParser) { implicit request =>
-      authorisedWithPptId.flatMap {
+      authorisedWithPptId(pptReference).flatMap {
         case Right(authorisedRequest) =>
           logger.info(s"Authorised request for ${authorisedRequest.pptId}")
           body(authorisedRequest)
@@ -67,18 +67,15 @@ class AuthenticatorImpl @Inject() (override val authConnector: AuthConnector, cc
       }
     }
 
-  def authorisedWithPptId[A](implicit
-    hc: HeaderCarrier,
-    request: Request[A]
-  ): Future[Either[ErrorResponse, AuthorizedRequest[A]]] =
-    authorised(Enrolment(pptEnrolmentKey)).retrieve(allEnrolments) { enrolments =>
-      hasEnrolment(enrolments, pptEnrolmentIdentifierName) match {
-        case Some(pptReference) => Future.successful(Right(AuthorizedRequest(pptReference.value, request)))
-        case _ =>
-          val msg = "Unauthorised access. User without PPT Id."
-          logger.error(msg)
-          Future.successful(Left(ErrorResponse(UNAUTHORIZED, msg)))
-      }
+  def authorisedWithPptId[A](
+    pptReference: String
+  )(implicit hc: HeaderCarrier, request: Request[A]): Future[Either[ErrorResponse, AuthorizedRequest[A]]] =
+    authorised(
+      Enrolment(pptEnrolmentKey).withDelegatedAuthRule("ppt-auth").withIdentifier(pptEnrolmentIdentifierName,
+                                                                                  pptReference
+      )
+    ).retrieve(allEnrolments) { _ =>
+      Future.successful(Right(AuthorizedRequest(pptReference, request)))
     } recover {
       case error: AuthorisationException =>
         logger.error(s"Unauthorised Exception for ${request.uri} with error ${error.reason}")
@@ -88,12 +85,6 @@ class AuthenticatorImpl @Inject() (override val authConnector: AuthConnector, cc
         logger.error(msg)
         Left(ErrorResponse(INTERNAL_SERVER_ERROR, msg))
     }
-
-  private def hasEnrolment(enrolmentsList: Enrolments, identifier: String): Option[EnrolmentIdentifier] =
-    enrolmentsList.enrolments
-      .filter(_.key == pptEnrolmentKey)
-      .flatMap(_.identifiers)
-      .find(_.key == identifier)
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorImpl.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorImpl.scala
@@ -57,7 +57,7 @@ class AuthenticatorImpl @Inject() (override val authConnector: AuthConnector, cc
     body: AuthorizedRequest[A] => Future[Result]
   ): Action[A] =
     Action.async(bodyParser) { implicit request =>
-      authorisedWithPptId(pptReference).flatMap {
+      authorisedWithPptReference(pptReference).flatMap {
         case Right(authorisedRequest) =>
           logger.info(s"Authorised request for ${authorisedRequest.pptId}")
           body(authorisedRequest)
@@ -67,7 +67,7 @@ class AuthenticatorImpl @Inject() (override val authConnector: AuthConnector, cc
       }
     }
 
-  def authorisedWithPptId[A](
+  def authorisedWithPptReference[A](
     pptReference: String
   )(implicit hc: HeaderCarrier, request: Request[A]): Future[Either[ErrorResponse, AuthorizedRequest[A]]] =
     authorised(

--- a/it/support/AuthTestSupport.scala
+++ b/it/support/AuthTestSupport.scala
@@ -42,7 +42,9 @@ trait AuthTestSupport extends MockitoSugar {
   val pptReference         = "7777777"
 
   private def enrolmentWithDelegatedAuth(pptReference: String) =
-    Enrolment(pptEnrolmentKey)//.withIdentifier(pptEnrolmentIdentifierName, pptReference).withDelegatedAuthRule("ppt-auth")
+    Enrolment(pptEnrolmentKey).withIdentifier(pptEnrolmentIdentifierName, pptReference).withDelegatedAuthRule(
+      "ppt-auth"
+    )
 
   def withAuthorizedUser(user: SignedInUser = newUser(Some(pptEnrolment(pptReference)))): Unit =
     when(

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorSpec.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions
 
-import org.scalatest.EitherValues
+import org.mockito.Mockito.reset
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers.await
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
+import uk.gov.hmrc.auth.core.{InsufficientEnrolments, InternalError}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.AuthAction.{
   pptEnrolmentIdentifierName,
@@ -33,78 +35,45 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import scala.concurrent.ExecutionContext
 
 class AuthenticatorSpec
-    extends AnyWordSpec with Matchers with MockitoSugar with AuthTestSupport with DefaultAwaitTimeout
-    with EitherValues {
+    extends AnyWordSpec with Matchers with MockitoSugar with AuthTestSupport with DefaultAwaitTimeout with EitherValues
+    with BeforeAndAfterEach {
 
   private val mcc           = stubMessagesControllerComponents()
   private val hc            = HeaderCarrier()
   private val request       = FakeRequest()
   private val authenticator = new AuthenticatorImpl(mockAuthConnector, mcc)(ExecutionContext.global)
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockAuthConnector)
+  }
+
   "Authenticator" should {
-    "return 401 unauthorised " when {
-      "missing ppt enrolment key" in {
-        withUserWithEnrolments(newUser(Some(newEnrolments(newEnrolment("rubbishKey", "id1", "val1")))))
+    "return left" when {
+      "auth returns Insufficient enrolments" in {
+        withUnauthorizedUser(InsufficientEnrolments())
 
-        val result = await(authenticator.authorisedWithPptId(hc, request))
-
-        result.left.value.statusCode mustBe 401
-      }
-      "missing ppt enrolment identifier" in {
-        withUserWithEnrolments(newUser(Some(newEnrolments(newEnrolment(pptEnrolmentKey, "id1", "val1")))))
-
-        val result = await(authenticator.authorisedWithPptId(hc, request))
+        val result = await(authenticator.authorisedWithPptId("someone-elses-ppt-account")(hc, request))
 
         result.left.value.statusCode mustBe 401
       }
-      "correct ppt enrolment identifier but no ppt enrolment key" in {
-        withUserWithEnrolments(
-          newUser(Some(newEnrolments(newEnrolment("someKey", pptEnrolmentIdentifierName, "val1"))))
-        )
 
-        val result = await(authenticator.authorisedWithPptId(hc, request))
+      "auth fails generally" in {
+        withUnauthorizedUser(InternalError("A general auth failure"))
+
+        val result = await(authenticator.authorisedWithPptId("val1")(hc, request))
 
         result.left.value.statusCode mustBe 401
       }
     }
 
-    "return 200" when {
-      "ppt enrolments exist" in {
-        withUserWithEnrolments(
+    "return right and populate verified ppt reference" when {
+      "ppt enrolment exists" in {
+        withAuthorizedUser(
           newUser(Some(newEnrolments(newEnrolment(pptEnrolmentKey, pptEnrolmentIdentifierName, "val1"))))
         )
 
-        val result = await(authenticator.authorisedWithPptId(hc, request))
-
-        result.value.pptId mustBe "val1"
-      }
-      "ppt enrolments exist among other enrolment keys" in {
-        withUserWithEnrolments(
-          newUser(
-            Some(
-              newEnrolments(newEnrolment(pptEnrolmentKey, pptEnrolmentIdentifierName, "val1"),
-                            newEnrolment("someKey", "someidentifier", "val2")
-              )
-            )
-          )
-        )
-
-        val result = await(authenticator.authorisedWithPptId(hc, request))
-
-        result.value.pptId mustBe "val1"
-      }
-      "multiple enrolment identifiers under same key" in {
-        withUserWithEnrolments(
-          newUser(
-            Some(
-              newEnrolments(newEnrolment(pptEnrolmentKey, pptEnrolmentIdentifierName, "val1"),
-                            newEnrolment(pptEnrolmentKey, "someidentifier", "val2")
-              )
-            )
-          )
-        )
-
-        val result = await(authenticator.authorisedWithPptId(hc, request))
+        val result = await(authenticator.authorisedWithPptId("val1")(hc, request))
 
         result.value.pptId mustBe "val1"
       }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/actions/AuthenticatorSpec.scala
@@ -53,7 +53,7 @@ class AuthenticatorSpec
       "auth returns Insufficient enrolments" in {
         withUnauthorizedUser(InsufficientEnrolments())
 
-        val result = await(authenticator.authorisedWithPptId("someone-elses-ppt-account")(hc, request))
+        val result = await(authenticator.authorisedWithPptReference("someone-elses-ppt-account")(hc, request))
 
         result.left.value.statusCode mustBe 401
       }
@@ -61,7 +61,7 @@ class AuthenticatorSpec
       "auth fails generally" in {
         withUnauthorizedUser(InternalError("A general auth failure"))
 
-        val result = await(authenticator.authorisedWithPptId("val1")(hc, request))
+        val result = await(authenticator.authorisedWithPptReference("val1")(hc, request))
 
         result.left.value.statusCode mustBe 401
       }
@@ -73,7 +73,7 @@ class AuthenticatorSpec
           newUser(Some(newEnrolments(newEnrolment(pptEnrolmentKey, pptEnrolmentIdentifierName, "val1"))))
         )
 
-        val result = await(authenticator.authorisedWithPptId("val1")(hc, request))
+        val result = await(authenticator.authorisedWithPptReference("val1")(hc, request))
 
         result.value.pptId mustBe "val1"
       }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/AuthTestSupport.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/AuthTestSupport.scala
@@ -42,24 +42,15 @@ trait AuthTestSupport extends MockitoSugar {
   val pptReference = "7777777"
 
   def enrolmentWithDelegatedAuth(pptReference: String) =
-    Enrolment(
-      pptEnrolmentKey
-    ) //.withIdentifier(pptEnrolmentIdentifierName, pptReference).withDelegatedAuthRule("ppt-auth")
+    Enrolment(pptEnrolmentKey).withIdentifier(pptEnrolmentIdentifierName, pptReference).withDelegatedAuthRule(
+      "ppt-auth"
+    )
 
   def withAuthorizedUser(user: SignedInUser = newUser(Some(pptEnrolment(pptReference)))): Unit =
     when(
       mockAuthConnector.authorise(ArgumentMatchers.argThat(pptEnrollmentMatcherForPptUser(user)),
                                   ArgumentMatchers.eq(allEnrolments)
       )(any(), any())
-    )
-      .thenReturn(Future.successful(user.enrolments))
-
-  def withUserWithEnrolments(user: SignedInUser) =
-    when(
-      mockAuthConnector.authorise(ArgumentMatchers.argThat((_: Predicate) => true), ArgumentMatchers.eq(allEnrolments))(
-        any(),
-        any()
-      )
     )
       .thenReturn(Future.successful(user.enrolments))
 


### PR DESCRIPTION
### Description of Work carried through

Auth calls include the parameters for agent's delegated enrolment check

The PPT reference is supplied in the API call so no longer needs to be extracted from the auth enrolments return; this is fortunate because an agent delegated enrolment is never rendered in the auth.enrolments response.

Protection against normal users supplying another user's ppt reference is still there because we are now supplying a specific enrolment identifier in the Enrolment predicate; auth will filter this for as (* citation needed)

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
