### PR TITLE
PPTP-1725 : Detect Deregistered Accounts - Premium Edition

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/EisFailure.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/connectors/models/eis/EisFailure.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis
+
+import play.api.libs.json.{Json, OFormat}
+
+case class EisError(code: String, reason: String)
+
+object EisError {
+  implicit val format: OFormat[EisError] = Json.format[EisError]
+}
+
+case class EisFailure(failures: Seq[EisError], httpCode: Int)
+
+object EisFailure {
+  implicit val format: OFormat[EisFailure] = Json.format[EisFailure]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/SubscriptionController.scala
@@ -50,8 +50,8 @@ class SubscriptionController @Inject() (
   def get(pptReference: String): Action[AnyContent] =
     authenticator.authorisedAction(parse.default, pptReference) { implicit request =>
       subscriptionsConnector.getSubscription(pptReference).map {
-        case Right(response)       => Ok(response)
-        case Left(errorStatusCode) => new Status(errorStatusCode)
+        case Right(response)  => Ok(response)
+        case Left(eisFailure) => new Status(eisFailure.httpCode)(eisFailure)
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/unit/MockConnectors.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/unit/MockConnectors.scala
@@ -37,12 +37,13 @@ import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscription
   SubscriptionUpdateSuccessfulResponse
 }
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors._
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.EisFailure
 import uk.gov.hmrc.plasticpackagingtaxreturns.models.nonRepudiation.{
   NonRepudiationMetadata,
   NonRepudiationSubmissionAccepted
 }
-import java.time.LocalDate
 
+import java.time.LocalDate
 import scala.concurrent.Future
 
 trait MockConnectors extends MockitoSugar with BeforeAndAfterEach {
@@ -63,15 +64,15 @@ trait MockConnectors extends MockitoSugar with BeforeAndAfterEach {
   protected def mockGetSubscriptionFailure(
     pptReference: String,
     statusCode: Int
-  ): OngoingStubbing[Future[Either[Int, SubscriptionDisplayResponse]]] =
+  ): OngoingStubbing[Future[Either[EisFailure, SubscriptionDisplayResponse]]] =
     when(mockSubscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).thenReturn(
-      Future.successful(Left(statusCode))
+      Future.successful(Left(EisFailure(Seq(), statusCode)))
     )
 
   protected def mockGetSubscription(
     pptReference: String,
     displayResponse: SubscriptionDisplayResponse
-  ): OngoingStubbing[Future[Either[Int, SubscriptionDisplayResponse]]] =
+  ): OngoingStubbing[Future[Either[EisFailure, SubscriptionDisplayResponse]]] =
     when(mockSubscriptionsConnector.getSubscription(ArgumentMatchers.eq(pptReference))(any[HeaderCarrier])).thenReturn(
       Future.successful(Right(displayResponse))
     )


### PR DESCRIPTION
Since we've extended deregistration detection at the front end to look for a specific error code in the get subscription response we need to ensure that this is propagated from EIS.

FE: https://github.com/hmrc/plastic-packaging-tax-returns-frontend/pull/168

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
