### PR TITLE
Add probe to obligations controller

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/PPTObligationsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/PPTObligationsController.scala
@@ -20,21 +20,22 @@ import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import uk.gov.hmrc.plasticpackagingtaxreturns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.ObligationsDataConnector
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.{ExportCreditBalanceConnector, ObligationsDataConnector}
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.des.enterprise.{ObligationDataResponse, ObligationStatus}
-import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.Authenticator
+import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.{Authenticator, AuthorizedRequest}
 import uk.gov.hmrc.plasticpackagingtaxreturns.services.PPTObligationsService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PPTObligationsController @Inject() (
   cc: ControllerComponents,
   authenticator: Authenticator,
   obligationsDataConnector: ObligationsDataConnector,
+  exportCreditBalanceConnector: ExportCreditBalanceConnector,
   obligationsService: PPTObligationsService,
   appConfig: AppConfig
 )(implicit val executionContext: ExecutionContext)
@@ -42,11 +43,21 @@ class PPTObligationsController @Inject() (
 
   private val internalServerError = InternalServerError("{}")
 
-  // todo dedupe
+  //will trigger calls to EIS in prod so we can see easily if/when this is working
+  def probeExportCreditBalance(pptReference: String)(implicit request: AuthorizedRequest[_]): Unit = {
+    exportCreditBalanceConnector
+      .getBalance(pptReference, LocalDate.now().minusYears(2), LocalDate.now().minusDays(1), request.internalId)
+      .map(_ => logger.info("Export Credit API call was: successful"))
+      .recover {
+        case _ => logger.info("Export Credit API call was: unsuccessful")
+      }
+  }
 
+  // todo dedupe
   def getOpen(pptReference: String): Action[AnyContent] =
     authenticator.authorisedAction(parse.default, pptReference) {
       implicit request =>
+        probeExportCreditBalance(pptReference) //only for testing credits error. delete me soon 30/9/2022
         obligationsDataConnector.get(pptReference, request.internalId, None, None, Some(ObligationStatus.OPEN)).map {
           case Left(404)                     => NotFound("{}")
           case Left(_)                       => internalServerError

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/controllers/PPTObligationsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/controllers/PPTObligationsControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.mvc.{ControllerComponents, Result}
 import play.api.test.Helpers.{status, _}
 import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.plasticpackagingtaxreturns.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.ObligationsDataConnector
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.{ExportCreditBalanceConnector, ObligationsDataConnector}
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.des.enterprise._
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.PPTObligationsController
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.it.FakeAuthenticator
@@ -50,8 +50,12 @@ class PPTObligationsControllerSpec extends PlaySpec with BeforeAndAfterEach with
 
   val cc: ControllerComponents = Helpers.stubControllerComponents()
 
+  //just to keep tests passing, this should be removed asap.
+  val mockExportConnectorTEMP: ExportCreditBalanceConnector = mock[ExportCreditBalanceConnector]
+  when(mockExportConnectorTEMP.getBalance(any(), any(), any(), any())(any())).thenReturn(Future.successful(Left(1)))
+
   val sut =
-    new PPTObligationsController(cc, new FakeAuthenticator(cc), mockObligationDataConnector, mockPPTObligationsService, appConfig)
+    new PPTObligationsController(cc, new FakeAuthenticator(cc), mockObligationDataConnector, mockExportConnectorTEMP, mockPPTObligationsService, appConfig)
 
   "getOpen" must {
     val obligations      = PPTObligations(None, None, 0, isNextObligationDue = false, displaySubmitReturnsLink = false)


### PR DESCRIPTION
ONLY TEMP

Obligations get open is called very often so would give sufficient calls
