### PR TITLE
Stop submission if already submitted/ not open

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/ReturnsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/ReturnsController.scala
@@ -129,7 +129,7 @@ class ReturnsController @Inject()(
     val periodKey = userAnswer.get(PeriodKeyGettable).get
     obligationsDataConnector.get(pptReference, request.internalId, None, None, Some(ObligationStatus.OPEN)).map {
       _.fold(
-        status => throw new RuntimeException(s"Could not get Direct Debit details. Server responded with status code: $status"),
+        status => throw new RuntimeException(s"Could not get Open Obligation details. Server responded with status code: $status"),
         _.obligations.flatMap(_.obligationDetails.map(_.periodKey)).contains(periodKey)
       )
     }

--- a/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/unit/MockConnectors.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/base/unit/MockConnectors.scala
@@ -25,7 +25,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors._
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.des.enterprise.{FinancialDataResponse, ObligationDataResponse}
+import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.des.enterprise.{FinancialDataResponse, Obligation, ObligationDataResponse, ObligationDetail, ObligationStatus}
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.exportcreditbalance.ExportCreditBalanceDisplayResponse
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.returns.Return
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.subscriptionDisplay.SubscriptionDisplayResponse
@@ -140,6 +140,26 @@ trait MockConnectors extends MockitoSugar with BeforeAndAfterEach {
         any()
       )(any[HeaderCarrier])
     ).thenReturn(Future.successful(Right(displayResponse)))
+
+  protected def mockGetObligationDataPeriodKey(
+                                       pptReference: String,
+                                       periodKey: String
+                                     ): OngoingStubbing[Future[Either[Int, ObligationDataResponse]]] =
+    when(
+      mockObligationDataConnector.get(ArgumentMatchers.eq(pptReference),
+        any(),
+        any(),
+        any(),
+        any()
+      )(any[HeaderCarrier])
+    ).thenReturn(
+      Future.successful(Right(
+          ObligationDataResponse(Seq(
+            Obligation(None, Seq(
+              ObligationDetail(ObligationStatus.OPEN, LocalDate.now(), LocalDate.now(), None, LocalDate.now(), periodKey))
+            )))
+      ))
+    )
 
   protected def mockGetObligationDataFailure(
                                               pptReference: String,


### PR DESCRIPTION
Point being frontend will now get back a **ExpectationFailed (417)** if user is spamming refresh. 
We could then handle this by giving the user some content like go check if its in your submitted returns, because etmp is telling us it is 
