### PR TITLE
PPTP-2804 - Dependency updates

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,8 +5,6 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
-
     <logger name="uk.gov.hmrc.plasticpackagingtaxreturns" level="${logger.ppt:-WARN}"/>
 
     <root level="${logger.application:-WARN}">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,12 +53,6 @@ play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 play.modules.enabled += "uk.gov.hmrc.plasticpackagingtaxreturns.config.Module"
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-# If you deploy your application to several instances be sure to use the same key!
-play.http.secret.key = "A2mNBjqcHsjP7uQN5o1oTMNryPOExWzq44keVA018vePLvFj0WuPTBDIeDuhtnaW"
-
 # The application languages
 # ~~~~~
 play.i18n.langs = ["en"]
@@ -84,12 +78,6 @@ play.http.router = prod.Routes
 controllers {
   # 300 is the default, you may need to change this according to your needs
   confidenceLevel = 300
-
-  uk.gov.hmrc.plasticpackagingtaxreturns.controllers.MicroserviceHelloWorldController = {
-    needsAuth = false
-    needsLogging = false
-    needsAuditing = false
-  }
 }
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,15 +3,18 @@ import sbt._
 
 object AppDependencies {
 
+  val bootstrapVersion = "5.20.0"
+  val mongoVersion = "0.74.0"
+
   val compile = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "5.16.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.68.0",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % mongoVersion,
     "com.typesafe.play" %% "play-json-joda"            % "2.6.14"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % "5.16.0",
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-27" % "0.56.0",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % bootstrapVersion,
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % mongoVersion,
     "org.scalatest"          %% "scalatest"               % "3.2.5", // Note - updating this appears to break flexmark-all
     "org.mockito"            %% "mockito-scala"           % "1.17.12",
     "com.typesafe.play"      %% "play-test"               % current,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "5.21.0"
+  val bootstrapVersion = "5.20.0"
   val mongoVersion = "0.74.0"
 
   val compile = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "5.20.0"
+  val bootstrapVersion = "5.21.0"
   val mongoVersion = "0.74.0"
 
   val compile = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "5.20.0"
+  val bootstrapVersion = "5.20.0" // Note - updating above this version introduces an issue with the LocalDate coming from Auth, will need further investigation.
   val mongoVersion = "0.74.0"
 
   val compile = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,10 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += Resolver.typesafeRepo("releases")
 
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
-
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
-
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
### Description of Work carried through

Brief description of what/why/how.

Also, removed this:

System property lookup can be removed in [conf/application-json-logger.xml](https://github.com/hmrc/plastic-packaging-tax-returns/blob/PPTP-2804/conf/application-json-logger.xml#L8) - Bootstrap's LoggerModule allows configuration of loggers without this. See README https://github.com/hmrc/bootstrap-play#version-5180

#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
