### PR TITLE
Fix problem where credits mini-cya can mistakenly complain...

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/ExportCreditBalanceController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/controllers/ExportCreditBalanceController.scala
@@ -55,6 +55,7 @@ class ExportCreditBalanceController @Inject() (
           taxRate
         )))
       }.recover{
+        // TODO do we still want this? seems to swallow log message when running service locally 
         case e: Exception => InternalServerError(Json.obj("message" -> JsString(e.getMessage)))
       }
     }

--- a/app/uk/gov/hmrc/plasticpackagingtaxreturns/services/AvailableCreditService.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtaxreturns/services/AvailableCreditService.scala
@@ -20,7 +20,7 @@ import com.google.inject.Inject
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.ExportCreditBalanceConnector
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.actions.AuthorizedRequest
 import uk.gov.hmrc.plasticpackagingtaxreturns.models.cache.UserAnswers
-import uk.gov.hmrc.plasticpackagingtaxreturns.models.cache.gettables.returns.{ConvertedCreditWeightGettable, ExportedCreditWeightGettable, ReturnObligationFromDateGettable}
+import uk.gov.hmrc.plasticpackagingtaxreturns.models.cache.gettables.returns.ReturnObligationFromDateGettable
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendHeaderCarrierProvider
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,23 +30,14 @@ class AvailableCreditService @Inject()(
 )(implicit executionContext: ExecutionContext) extends BackendHeaderCarrierProvider {
 
   def getBalance(userAnswers: UserAnswers)(implicit request: AuthorizedRequest[_]): Future[BigDecimal] = {
-    val obligationFromDate = userAnswers.get(ReturnObligationFromDateGettable).getOrElse(
-      throw new IllegalStateException("Obligation fromDate not found in user-answers")
-    )
-
+    val obligationFromDate = userAnswers.getOrFail(ReturnObligationFromDateGettable)
     val fromDate = obligationFromDate.minusYears(2)
     val toDate = obligationFromDate.minusDays(1)
-    val totalRequestedCredit: Long = 
-      userAnswers.get(ConvertedCreditWeightGettable).getOrElse(0L) 
-      + userAnswers.get(ExportedCreditWeightGettable).getOrElse(0L)
-    if (totalRequestedCredit == 0)
-      Future.successful(BigDecimal(0))
-    else
-      exportCreditBalanceConnector
-        .getBalance(request.pptReference, fromDate, toDate, request.internalId)
-        .map(
-          _.fold(e => throw new Exception(s"Error calling EIS export credit, status: $e"), _.totalExportCreditAvailable)
-        )
+    exportCreditBalanceConnector
+      .getBalance(request.pptReference, fromDate, toDate, request.internalId)
+      .map(
+        _.fold(e => throw new Exception(s"Error calling EIS export credit, status: $e"), _.totalExportCreditAvailable)
+      )
   }
 
 }

--- a/it/returns/CalculationsISpec.scala
+++ b/it/returns/CalculationsISpec.scala
@@ -28,7 +28,7 @@ import play.api.Application
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, UNAUTHORIZED, UNPROCESSABLE_ENTITY}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import support.WiremockItServer
@@ -78,6 +78,7 @@ class CalculationsISpec extends PlaySpec with GuiceOneServerPerSuite with AuthTe
         when(sessionRepository.get(any))
           .thenReturn(Future.successful(Some(UserAnswers(pptReference, ReturnTestHelper.returnsWithNoCreditDataJson))))
         withAuthorizedUser()
+        stubGetBalanceRequest
 
         val result = await(wsClient.url(s"http://localhost:$port/returns-calculate/$pptReference").get)
 
@@ -196,7 +197,7 @@ class CalculationsISpec extends PlaySpec with GuiceOneServerPerSuite with AuthTe
 
   private def stubGetBalanceRequest =
     server.stubFor(
-      get(s"/plastic-packaging-tax/export-credits/PPT/$pptReference")
+      get(urlPathEqualTo(s"/plastic-packaging-tax/export-credits/PPT/$pptReference"))
         .willReturn(ok().withBody(Json.toJson(ReturnTestHelper.createCreditBalanceDisplayResponse).toString()))
     )
 

--- a/it/returns/ReturnsISpec.scala
+++ b/it/returns/ReturnsISpec.scala
@@ -34,12 +34,10 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import support.{ObligationSpecHelper, ReturnWireMockServerSpec}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.des.enterprise._
-import uk.gov.hmrc.plasticpackagingtaxreturns.connectors.models.eis.exportcreditbalance.ExportCreditBalanceDisplayResponse
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.ReturnsController.ReturnWithTaxRate
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.base.AuthTestSupport
 import uk.gov.hmrc.plasticpackagingtaxreturns.controllers.models.NrsTestData
 import uk.gov.hmrc.plasticpackagingtaxreturns.models.cache.UserAnswers
-import uk.gov.hmrc.plasticpackagingtaxreturns.models.cache.gettables.amends.{IdDetails, ReturnDisplayApi, ReturnDisplayDetails}
 import uk.gov.hmrc.plasticpackagingtaxreturns.repositories.SessionRepository
 import uk.gov.hmrc.plasticpackagingtaxreturns.services.nonRepudiation.NonRepudiationService
 import uk.gov.hmrc.plasticpackagingtaxreturns.support.ReturnTestHelper
@@ -88,7 +86,7 @@ class ReturnsISpec extends PlaySpec
 
   "return 200 when getting return details" in {
     withAuthorizedUser()
-    stubReturnDisplayResponse
+    stubReturnDisplayResponse()
 
     val response = await(wsClient.url(validGetReturnDisplayUrl).get())
 
@@ -97,7 +95,7 @@ class ReturnsISpec extends PlaySpec
 
   "return display details" in {
     withAuthorizedUser()
-    stubReturnDisplayResponse
+    stubReturnDisplayResponse()
 
     val response = await(wsClient.url(validGetReturnDisplayUrl).get())
     val expected = ReturnWithTaxRate(Json.parse(displayApiResponse), 0.2)
@@ -107,7 +105,7 @@ class ReturnsISpec extends PlaySpec
 
   "return an error if DES API fails when getting return" in {
     withAuthorizedUser()
-    stubReturnDisplayErrorResponse
+    stubReturnDisplayErrorResponse()
 
     val response = await(wsClient.url(validGetReturnDisplayUrl).get())
 
@@ -125,8 +123,8 @@ class ReturnsISpec extends PlaySpec
   "return 200 when submitting return" in {
     withAuthorizedUser()
     mockAuthorization(NonRepudiationService.nonRepudiationIdentityRetrievals, testAuthRetrievals)
-    setUpStub
-    setUpMocks
+    setUpStub()
+    setUpMocks()
 
     val response = await(wsClient.url(submitReturnUrl).withHttpHeaders("Authorization" -> "TOKEN").post(pptReference))
 
@@ -136,8 +134,8 @@ class ReturnsISpec extends PlaySpec
   "success return submit with nrs success" in {
     withAuthorizedUser()
     mockAuthorization(NonRepudiationService.nonRepudiationIdentityRetrievals, testAuthRetrievals)
-    setUpStub
-    setUpMocks
+    setUpStub()
+    setUpMocks()
 
     val response = await(wsClient.url(submitReturnUrl).withHttpHeaders("Authorization" -> "TOKEN").post(pptReference))
 
@@ -148,8 +146,8 @@ class ReturnsISpec extends PlaySpec
   "success return submit with nrs failure" in {
     withAuthorizedUser()
     mockAuthorization(NonRepudiationService.nonRepudiationIdentityRetrievals, testAuthRetrievals)
-    setUpStub
-    setUpMocks
+    setUpStub()
+    setUpMocks()
     stubNrsFailingRequest
 
     val response = await(wsClient.url(submitReturnUrl).withHttpHeaders("Authorization" -> "TOKEN").post(pptReference))
@@ -178,14 +176,14 @@ class ReturnsISpec extends PlaySpec
     response.status mustBe UNAUTHORIZED
   }
 
-  private def setUpStub = {
+  private def setUpStub() = {
     stubObligationDesRequest()
     stubGetBalanceEISRequest
     stubSubmitReturnEISRequest(pptReference)
     stubNrsRequest
   }
 
-  private def setUpMocks = {
+  private def setUpMocks() = {
     when(cacheRepository.get(any())).thenReturn(Future.successful(Option(UserAnswers("id").copy(
       data = ReturnTestHelper.returnsWithNoCreditDataJson))))
     when(cacheRepository.clear(any[String]())).thenReturn(Future.successful(true))
@@ -204,7 +202,7 @@ class ReturnsISpec extends PlaySpec
     )
   }
 
-  private def stubReturnDisplayResponse: Unit = {
+  private def stubReturnDisplayResponse(): Unit = {
     server.stubFor(
       get(DesUrl)
         .willReturn(
@@ -215,7 +213,7 @@ class ReturnsISpec extends PlaySpec
     )
   }
 
-  private def stubReturnDisplayErrorResponse: Unit = {
+  private def stubReturnDisplayErrorResponse(): Unit = {
     server.stubFor(
       get(DesUrl)
         .willReturn(
@@ -226,28 +224,10 @@ class ReturnsISpec extends PlaySpec
   }
 
   private def stubGetBalanceEISRequest = {
-    server.stubFor(get(balanceEISURL)
+    server.stubFor(get(urlPathEqualTo(balanceEISURL))
       .willReturn(
         ok().withBody(Json.toJson(ReturnTestHelper.createCreditBalanceDisplayResponse).toString())
       )
-    )
-  }
-
-  private def createDisplayApiResponse: ReturnDisplayApi = {
-    ReturnDisplayApi(
-      ReturnDisplayDetails(
-        manufacturedWeight = 250L,
-        importedWeight = 150L,
-        totalNotLiable = 180L,
-        humanMedicines = 50L,
-        directExports = 60L,
-        recycledPlastic = 70L,
-        creditForPeriod = BigDecimal(12.13),
-        debitForPeriod = BigDecimal(0),
-        totalWeight = 220L,
-        taxDue = BigDecimal(44)
-      ),
-      idDetails = IdDetails(pptReferenceNumber = pptReference, submissionId = "123456789012")
     )
   }
 

--- a/it/returns/credits/ExportCreditBalanceControllerItSpec.scala
+++ b/it/returns/credits/ExportCreditBalanceControllerItSpec.scala
@@ -78,6 +78,7 @@ class ExportCreditBalanceControllerItSpec extends PlaySpec
     "return 200" when {
       "total requested credit is 0 "in {
         withAuthorizedUser()
+        stubGetBalanceResponse()
         when(sessionRepository.get(any))
           .thenReturn(Future.successful(Some(UserAnswers(pptReference, jsonObj))))
 
@@ -88,7 +89,7 @@ class ExportCreditBalanceControllerItSpec extends PlaySpec
 
       "total requested credit is not 0" in {
         withAuthorizedUser()
-        stubGetBalanceResponse
+        stubGetBalanceResponse()
         when(sessionRepository.get(any))
           .thenReturn(Future.successful(Some(UserAnswers(pptReference, jsonWitTotalRequestedCredit))))
 
@@ -100,7 +101,7 @@ class ExportCreditBalanceControllerItSpec extends PlaySpec
 
     "return json" in {
       withAuthorizedUser()
-      stubGetBalanceResponse
+      stubGetBalanceResponse()
 
       when(sessionRepository.get(any))
         .thenReturn(Future.successful(Some(UserAnswers(pptReference, jsonWitTotalRequestedCredit))))
@@ -137,7 +138,7 @@ class ExportCreditBalanceControllerItSpec extends PlaySpec
     s"""{
        |"obligation": {
        | "fromDate": "${fromDate.toString}",
-       | "toDate": "${toDate.toString()}"
+       | "toDate": "${toDate.toString}"
        | },
        | "convertedCredits": "0",
        | "exportedCredits": "0"
@@ -147,7 +148,7 @@ class ExportCreditBalanceControllerItSpec extends PlaySpec
     s"""{
        |"obligation": {
        | "fromDate": "${fromDate.toString}",
-       |  "toDate": "${toDate.toString()}"
+       |  "toDate": "${toDate.toString}"
        | },
        | "convertedCredits": { "yesNo": true, "weight": 10 },
        | "exportedCredits": { "yesNo": true, "weight": 5 }
@@ -160,7 +161,8 @@ class ExportCreditBalanceControllerItSpec extends PlaySpec
     totalExportCreditClaimed = BigDecimal(100),
     totalExportCreditAvailable = BigDecimal(200)
   )
-  private def stubGetBalanceResponse: Unit = {
+  
+  private def stubGetBalanceResponse() = {
 
     val date = fromDate.minusYears(2)
     val toDate = fromDate.minusDays(1)


### PR DESCRIPTION
...credit claim is too high. Also fix slight bug in wiremock stub for ExportCreditBalanceControllerItSpec, CalculationsISpec, and CalculationsISpec